### PR TITLE
docs: fix plugin install instructions to match official Claude docs

### DIFF
--- a/docs/blog/2026-04-10-praman-claude-code-plugin.md
+++ b/docs/blog/2026-04-10-praman-claude-code-plugin.md
@@ -29,10 +29,11 @@ The [Praman CLI agents](/blog/2026/04/05/how-to-use-praman-cli-agents) showed th
 Today we're releasing **two plugins** that change that — one for **Claude Code** and one for **Claude Cowork**. Same 5-agent pipeline, same compliance rules, two interfaces.
 
 ```bash
-# Claude Code — CLI-first
-claude plugin add praman-sap-testing
+# Claude Code — CLI
+claude plugin marketplace add mrkanitkar/praman-sap-testing
+claude plugin install praman-sap-testing@praman-sap-testing
 
-# Claude Cowork — install the .plugin file from the chat interface
+# Claude Cowork — Customize → Browse plugins → Install
 ```
 
 <!-- truncate -->
@@ -55,7 +56,7 @@ For developers and test automation engineers who work in the terminal. Install v
 
 ### Claude Cowork Plugin
 
-For teams that prefer a chat-first, collaborative interface. Install by dragging the `.plugin` file into Cowork. Same agents, same rules — but with collaborative review, shared sessions, and team-visible test results.
+For teams that prefer a chat-first, collaborative interface. Install from **Customize → Browse plugins** in Claude Cowork. Same agents, same rules — but with collaborative review, shared sessions, and team-visible test results.
 
 Both plugins are the orchestration layer that CLI agents lacked.
 
@@ -213,16 +214,16 @@ The quality gate greps for `page.click(` in every generated file. A single match
 
 If you've read the [CLI agents walkthrough](/blog/2026/04/05/how-to-use-praman-cli-agents), you might wonder: what's different?
 
-| Aspect            | CLI Agents                            | Claude Code Plugin                     | Claude Cowork Plugin            |
-| ----------------- | ------------------------------------- | -------------------------------------- | ------------------------------- |
-| **Installation**  | Copy `.md` files to `.claude/agents/` | `claude plugin add praman-sap-testing` | Drag-and-drop `.plugin` file    |
-| **Shared rules**  | None — standalone                     | `CLAUDE.md` + 7 rules                  | `CLAUDE.md` + 7 rules           |
-| **Commands**      | None — invoke by name                 | 4 slash commands                       | Chat-based invocation           |
-| **Quality gate**  | Manual                                | Automatic                              | Automatic                       |
-| **Session hook**  | None                                  | Rules reminder on every session        | Rules reminder on every session |
-| **Skill routing** | Agent reads its own file              | 8 skills auto-activate                 | 8 skills auto-activate          |
-| **Pipeline**      | Manual — one by one                   | `/praman-coverage` runs all            | Chat-driven pipeline            |
-| **Collaboration** | Single user                           | Single user                            | Team-visible reviews            |
+| Aspect            | CLI Agents                            | Claude Code Plugin              | Claude Cowork Plugin            |
+| ----------------- | ------------------------------------- | ------------------------------- | ------------------------------- |
+| **Installation**  | Copy `.md` files to `.claude/agents/` | `claude plugin install` via CLI | GUI: Customize → Browse plugins |
+| **Shared rules**  | None — standalone                     | `CLAUDE.md` + 7 rules           | `CLAUDE.md` + 7 rules           |
+| **Commands**      | None — invoke by name                 | 4 slash commands                | Chat-based invocation           |
+| **Quality gate**  | Manual                                | Automatic                       | Automatic                       |
+| **Session hook**  | None                                  | Rules reminder on every session | Rules reminder on every session |
+| **Skill routing** | Agent reads its own file              | 8 skills auto-activate          | 8 skills auto-activate          |
+| **Pipeline**      | Manual — one by one                   | `/praman-coverage` runs all     | Chat-driven pipeline            |
+| **Collaboration** | Single user                           | Single user                     | Team-visible reviews            |
 
 **When to use CLI agents**: Custom agent setups, per-project files, environments where plugins aren't supported.
 
@@ -238,7 +239,8 @@ If you've read the [CLI agents walkthrough](/blog/2026/04/05/how-to-use-praman-c
 
 ```bash
 # 1. Install the plugin
-claude plugin add praman-sap-testing
+claude plugin marketplace add mrkanitkar/praman-sap-testing
+claude plugin install praman-sap-testing@praman-sap-testing
 
 # 2. Set up environment variables
 export SAP_CLOUD_BASE_URL="https://your-system.s4hana.cloud.sap/"
@@ -255,8 +257,8 @@ npm install -D playwright-praman @playwright/test
 
 ### Claude Cowork
 
-1. Download the `praman-sap-testing.plugin` file
-2. Drag-and-drop into Claude Cowork chat interface
+1. Open Claude Desktop → **Cowork** tab → **Customize** → **Browse plugins**
+2. Search for **praman-sap-testing** and click **Install**
 3. Set SAP environment variables in your project
 4. Ask: "Plan and generate tests for Manage Purchase Orders"
 

--- a/docs/docs/guides/claude-code-plugin-installation.md
+++ b/docs/docs/guides/claude-code-plugin-installation.md
@@ -46,20 +46,34 @@ npm install -g @playwright/cli@latest
 
 ## Step 1: Install the Plugin
 
+### Claude Code (CLI)
+
 ```bash
-claude plugin add praman-sap-testing
+# Add the marketplace (one-time)
+claude plugin marketplace add mrkanitkar/praman-sap-testing
+
+# Install the plugin
+claude plugin install praman-sap-testing@praman-sap-testing
 ```
 
 This registers the plugin with Claude Code and makes the four slash commands available:
 `/praman-plan`, `/praman-generate`, `/praman-heal`, and `/praman-coverage`.
 
-Verify the plugin loaded:
+### Claude Cowork (Desktop App)
 
-```bash
-claude plugin list
-```
+1. Open Claude Desktop and switch to the **Cowork** tab
+2. Click **Customize** in the left sidebar
+3. Click **Browse plugins**
+4. Search for **praman-sap-testing** and click **Install**
 
-You should see `praman-sap-testing` in the output with status `active`.
+For organizations not on the public marketplace, an admin can upload the plugin via
+**Organization settings → Plugins → Add plugins → Upload a file**. Download
+`praman-sap-testing.zip` from the
+[latest release](https://github.com/mrkanitkar/praman-sap-testing/releases/latest).
+
+### Verify
+
+Type `/praman-` in Claude Code or Cowork and autocomplete should show 4 commands.
 
 ## Step 2: Configure Environment Variables
 
@@ -309,20 +323,20 @@ This is separate from `npx playwright install chromium`, which installs browsers
 Run through this checklist after completing setup. Every item should pass before using
 the plugin commands.
 
-| Check                     | Command                                                                 | Expected Result                           |
-| ------------------------- | ----------------------------------------------------------------------- | ----------------------------------------- |
-| Plugin installed          | `claude plugin list`                                                    | `praman-sap-testing` with status `active` |
-| Node.js version           | `node --version`                                                        | `v20.x.x` or higher                       |
-| Playwright installed      | `npx playwright --version`                                              | `1.48.0` or higher                        |
-| CLI installed             | `npx @playwright/cli --version`                                         | Version number (no error)                 |
-| npm package installed     | `npm ls playwright-praman`                                              | Package listed with version               |
-| Bridge script exists      | `ls node_modules/playwright-praman/dist/browser/praman-bridge-init.js`  | File exists                               |
-| CLI config exists         | `ls .playwright/praman-cli.config.json`                                 | File exists                               |
-| Env vars set              | `grep SAP_CLOUD_BASE_URL .env.test`                                     | URL present                               |
-| Auth state exists         | `ls .auth/sap-session.json`                                             | File exists (after running auth setup)    |
-| Doctor passes             | `npx playwright-praman doctor`                                          | All checks green                          |
-| Bridge loads              | `npx @playwright/cli eval "() => window.__praman_bridge !== undefined"` | `true`                                    |
-| Plugin commands available | Type `/praman-` in Claude Code                                          | Autocomplete shows 4 commands             |
+| Check                     | Command                                                                 | Expected Result                        |
+| ------------------------- | ----------------------------------------------------------------------- | -------------------------------------- |
+| Plugin installed          | Type `/praman-` in Claude Code                                          | Autocomplete shows 4 commands          |
+| Node.js version           | `node --version`                                                        | `v20.x.x` or higher                    |
+| Playwright installed      | `npx playwright --version`                                              | `1.48.0` or higher                     |
+| CLI installed             | `npx @playwright/cli --version`                                         | Version number (no error)              |
+| npm package installed     | `npm ls playwright-praman`                                              | Package listed with version            |
+| Bridge script exists      | `ls node_modules/playwright-praman/dist/browser/praman-bridge-init.js`  | File exists                            |
+| CLI config exists         | `ls .playwright/praman-cli.config.json`                                 | File exists                            |
+| Env vars set              | `grep SAP_CLOUD_BASE_URL .env.test`                                     | URL present                            |
+| Auth state exists         | `ls .auth/sap-session.json`                                             | File exists (after running auth setup) |
+| Doctor passes             | `npx playwright-praman doctor`                                          | All checks green                       |
+| Bridge loads              | `npx @playwright/cli eval "() => window.__praman_bridge !== undefined"` | `true`                                 |
+| Plugin commands available | Type `/praman-` in Claude Code                                          | Autocomplete shows 4 commands          |
 
 ## FAQ
 
@@ -352,13 +366,12 @@ registering the strategy with the `sapAuth` fixture.
 
 Three checks confirm the plugin is active:
 
-1. `claude plugin list` shows `praman-sap-testing` with status `active`
-2. Typing `/praman-` in Claude Code shows autocomplete for the four commands
-3. Running `/praman-plan` with a prompt starts the sap-explorer agent (you will see
+1. Typing `/praman-` in Claude Code shows autocomplete for the four commands
+2. Running `/praman-plan` with a prompt starts the sap-explorer agent (you will see
    yellow-colored agent output in the Claude Code terminal)
 
-If the plugin does not appear, reinstall with `claude plugin add praman-sap-testing` and
-restart Claude Code.
+If the plugin does not appear, reinstall with
+`claude plugin install praman-sap-testing@praman-sap-testing` and restart Claude Code.
 
 </details>
 

--- a/docs/docs/guides/claude-code-plugin-overview.md
+++ b/docs/docs/guides/claude-code-plugin-overview.md
@@ -100,7 +100,7 @@ the same project.
 
 | Aspect                 | Plugin                                       | CLI Agents                          | MCP Agents                              |
 | ---------------------- | -------------------------------------------- | ----------------------------------- | --------------------------------------- |
-| **Installation**       | `claude plugin add praman-sap-testing`       | `.md` files in `.claude/agents/`    | `@playwright/mcp` server in `.mcp.json` |
+| **Installation**       | `claude plugin install` via marketplace      | `.md` files in `.claude/agents/`    | `@playwright/mcp` server in `.mcp.json` |
 | **Shared rules**       | Yes (plugin enforces 7 rules, 19 patterns)   | No (each agent file is standalone)  | No (rules embedded per-agent)           |
 | **Command pipeline**   | Yes (`/praman-coverage` chains all stages)   | Manual (run each agent separately)  | Manual (invoke MCP tools individually)  |
 | **Session hooks**      | Yes (pre/post hooks for auth, cleanup)       | No                                  | No                                      |
@@ -121,7 +121,8 @@ the same project.
 
 :::warning[Common mistake]
 Trying to use plugin commands (`/praman-plan`, `/praman-generate`) without installing the
-plugin first. These commands are not available until you run `claude plugin add praman-sap-testing`.
+plugin first. These commands are not available until you install the plugin via the marketplace
+(see [Installation](./claude-code-plugin-installation)).
 If you only have CLI agent `.md` files in `.claude/agents/`, use the CLI commands instead
 (`/praman-cli-plan`, `/praman-cli-generate`).
 :::

--- a/docs/docs/guides/claude-cowork-plugin.md
+++ b/docs/docs/guides/claude-cowork-plugin.md
@@ -14,7 +14,7 @@ keywords:
 
 :::info[In this guide]
 
-- Install the Praman plugin in Claude Cowork via drag-and-drop
+- Install the Praman plugin in Claude Cowork via the Customize menu
 - Understand how the same 5-agent pipeline works in a chat-first interface
 - Run plan-generate-heal through natural language requests
 - Collaborate with your team on test reviews and approvals
@@ -30,14 +30,14 @@ confidence-scored healing — but with a chat-first interface designed for team 
 
 Both plugins share identical internals. The difference is the interface and collaboration model.
 
-| Aspect            | Claude Code Plugin                     | Claude Cowork Plugin                     |
-| ----------------- | -------------------------------------- | ---------------------------------------- |
-| **Interface**     | Terminal / CLI                         | Chat / conversational                    |
-| **Installation**  | `claude plugin add praman-sap-testing` | Drag-and-drop `.plugin` file             |
-| **Invocation**    | Slash commands (`/praman-plan`)        | Natural language requests                |
-| **Collaboration** | Single user                            | Team-visible sessions                    |
-| **Review**        | User gates in terminal                 | Collaborative review in chat             |
-| **Best for**      | Developers, CI pipelines               | Teams, business analysts, shared reviews |
+| Aspect            | Claude Code Plugin              | Claude Cowork Plugin                     |
+| ----------------- | ------------------------------- | ---------------------------------------- |
+| **Interface**     | Terminal / CLI                  | Chat / conversational                    |
+| **Installation**  | `claude plugin install` via CLI | GUI: Customize → Browse plugins          |
+| **Invocation**    | Slash commands (`/praman-plan`) | Natural language requests                |
+| **Collaboration** | Single user                     | Team-visible sessions                    |
+| **Review**        | User gates in terminal          | Collaborative review in chat             |
+| **Best for**      | Developers, CI pipelines        | Teams, business analysts, shared reviews |
 
 :::tip
 If you're already familiar with the [Claude Code Plugin](/docs/guides/claude-code-plugin-overview),
@@ -69,18 +69,19 @@ export SAP_CLOUD_PASSWORD="your-password"
 
 ### Install the Plugin
 
-1. Download or build the `praman-sap-testing.plugin` file:
+1. Open Claude Desktop and switch to the **Cowork** tab
+2. Click **Customize** in the left sidebar
+3. Click **Browse plugins**
+4. Search for **praman-sap-testing** and click **Install**
 
-```bash
-# From the plugin source directory
-bash scripts/package-cowork.sh
-# Output: dist/praman-sap-testing.plugin
-```
+For organizations not on the public marketplace, an admin can upload the plugin:
 
-1. In Claude Cowork, drag-and-drop the `.plugin` file into the chat interface — or use the
-   plugin installer from the Cowork menu.
+1. Download `praman-sap-testing.zip` from the
+   [latest release](https://github.com/mrkanitkar/praman-sap-testing/releases/latest)
+2. Go to **Organization settings → Plugins → Add plugins → Upload a file**
+3. Select the downloaded `.zip` file
 
-1. Verify the plugin loaded by asking:
+Verify the plugin loaded by asking:
 
 ```text
 What Praman agents and skills are available?
@@ -259,22 +260,18 @@ how you invoke the pipeline and review results.
 ## Troubleshooting
 
 <details>
-<summary>Plugin not loading after drag-and-drop?</summary>
+<summary>Plugin not appearing in Browse plugins?</summary>
 
-Ensure the `.plugin` file was packaged correctly:
+If the plugin is not listed in the marketplace, install it manually:
 
-```bash
-cd plugins/praman-sap-testing
-bash scripts/package-cowork.sh
-```
+1. Download `praman-sap-testing.zip` from the
+   [latest release](https://github.com/mrkanitkar/praman-sap-testing/releases/latest)
+2. Ask your organization admin to upload it via
+   **Organization settings → Plugins → Add plugins → Upload a file**
 
-The output should be `dist/praman-sap-testing.plugin`. Verify it contains the expected files:
-
-```bash
-unzip -l dist/praman-sap-testing.plugin | head -20
-```
-
-You should see `.claude-plugin/plugin.json`, `agents/`, `skills/`, `commands/`, and `CLAUDE.md`.
+The `.zip` must contain `.claude-plugin/plugin.json`, `agents/`, `skills/`, and `commands/`
+at the root level. Note: Cowork's upload dialog accepts `.zip` files only — if you have a
+`.plugin` file, rename it to `.zip` before uploading.
 
 </details>
 
@@ -300,15 +297,10 @@ failures in Claude Code. The generated test files are identical and interchangea
 <details>
 <summary>How do I update the Cowork plugin?</summary>
 
-Re-package the plugin from the latest source and drag-and-drop the new `.plugin` file into
-Cowork. It replaces the existing installation.
-
-```bash
-cd plugins/praman-sap-testing
-git pull
-bash scripts/package-cowork.sh
-# Drag dist/praman-sap-testing.plugin into Cowork
-```
+If the plugin is in a marketplace, go to **Customize → Browse plugins** and check for
+updates. For manual uploads, download the latest `.zip` from the
+[releases page](https://github.com/mrkanitkar/praman-sap-testing/releases/latest)
+and re-upload via **Organization settings → Plugins → Add plugins → Upload a file**.
 
 </details>
 


### PR DESCRIPTION
## Summary

- Fix Claude Code plugin install commands: `claude plugin marketplace add` + `claude plugin install` (not `claude plugin add`)
- Fix Cowork plugin guide: GUI-only install (Customize → Browse plugins), not drag-and-drop
- Fix plugin overview comparison table and common mistake admonition
- Fix blog post install commands and Getting Started section

## Files changed (4)

| File | Change |
|------|--------|
| `docs/docs/guides/claude-code-plugin-installation.md` | Marketplace install flow, Cowork GUI section |
| `docs/docs/guides/claude-cowork-plugin.md` | Remove drag-and-drop, add GUI + org upload |
| `docs/docs/guides/claude-code-plugin-overview.md` | Fix comparison table, common mistake warning |
| `docs/blog/2026-04-10-praman-claude-code-plugin.md` | Fix install commands, Getting Started |

## Context

Companion to mrkanitkar/praman-sap-testing#8. Research against official Anthropic docs:
- Claude Code: `claude plugin marketplace add` + `claude plugin install`
- Cowork: GUI-only — Customize → Browse plugins → Install
- Cowork upload: `.zip` only (anthropics/claude-code#28337)

## Test plan

- [x] `grep -r "claude plugin add" docs/` — no results
- [x] `grep -ri "drag.and.drop" docs/docs/guides/claude-co*` — no results
- [ ] `cd docs && npm run build` — verify no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)