### PR TITLE
chore(deps): bump zod 4.3.6 to 4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "css-selector-parser": "3.3.0",
         "fontoxpath": "3.34.0",
         "pino": "10.3.1",
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "bin": {
         "playwright-praman": "dist/cli/index.js"
@@ -28103,7 +28103,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "css-selector-parser": "3.3.0",
     "fontoxpath": "3.34.0",
     "pino": "10.3.1",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.78.0",


### PR DESCRIPTION
## Summary

- Bump `zod` from 4.3.6 to 4.4.3 — **runtime dependency** (`dependencies`, not `devDependencies`)
- Isolated in its own PR for easy revert since this ships to end-users
- All standard Zod 4 APIs unchanged (`z.object`, `z.enum`, `z.url`, `safeParse`, `z.infer<>`)

## Test plan

- [x] `npm run ci` passes (lint, typecheck, 4460 tests, build)
- [x] `npm run check:exports` — all 6 sub-path exports resolve correctly
- [x] No source code changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)