### PR TITLE
chore(deps): bump LLM SDKs and OpenTelemetry suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19316,7 +19316,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20692,19 +20694,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/knip/node_modules/get-tsconfig": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/knip/node_modules/strip-json-comments": {


### PR DESCRIPTION
## Summary
- Bump `@anthropic-ai/sdk` from 0.91.1 to 0.98.0
- Bump `openai` from 6.33.0 to 6.39.0
- Bump all 6 OpenTelemetry packages together (internal version contract):
  - `@opentelemetry/exporter-metrics-otlp-http` 0.214.0 → 0.218.0
  - `@opentelemetry/exporter-trace-otlp-http` 0.214.0 → 0.218.0
  - `@opentelemetry/resources` 2.6.1 → 2.7.1
  - `@opentelemetry/sdk-metrics` 2.6.1 → 2.7.1
  - `@opentelemetry/sdk-node` 0.214.0 → 0.218.0
  - `@opentelemetry/sdk-trace-base` 2.6.1 → 2.7.1

All are devDependencies with optional peer deps. All use dynamic imports with graceful fallbacks — no breaking API surface changes.

## Test plan
- [x] `npm run ci` passes (lint, typecheck, 4460 unit tests, build)
- [x] Pre-push hooks pass (spellcheck, coverage, build)
- [ ] Verify `src/ai/llm-providers.ts` dynamic imports work at runtime
- [ ] Verify OTel telemetry reporter initializes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)