### PR TITLE
fix(deps): restore zod 4.4.3, bump dotenv 17.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "css-selector-parser": "3.3.0",
         "fontoxpath": "3.34.0",
         "pino": "10.3.1",
-        "zod": "4.3.6"
+        "zod": "4.4.3"
       },
       "bin": {
         "playwright-praman": "dist/cli/index.js"
@@ -43,7 +43,7 @@
         "@vitest/coverage-v8": "4.1.7",
         "@vitest/ui": "4.1.7",
         "cspell": "10.0.0",
-        "dotenv": "^17.4.1",
+        "dotenv": "^17.4.2",
         "esbuild": "0.28.0",
         "eslint": "10.4.0",
         "eslint-config-prettier": "10.1.8",
@@ -17749,9 +17749,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.4.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
-      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -27138,9 +27138,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "css-selector-parser": "3.3.0",
     "fontoxpath": "3.34.0",
     "pino": "10.3.1",
-    "zod": "4.3.6"
+    "zod": "4.4.3"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.78.0",
@@ -244,7 +244,7 @@
     "@vitest/coverage-v8": "4.1.7",
     "@vitest/ui": "4.1.7",
     "cspell": "10.0.0",
-    "dotenv": "^17.4.1",
+    "dotenv": "^17.4.2",
     "esbuild": "0.28.0",
     "eslint": "10.4.0",
     "eslint-config-prettier": "10.1.8",


### PR DESCRIPTION
## Summary
- Restores `zod` from 4.3.6 → 4.4.3 (production dep accidentally downgraded during Dependabot batch merge #142)
- Bumps `dotenv` from 17.4.1 → 17.4.2 (devDependency patch)

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run test:unit` — 4,460 tests passed
- [x] `npm run build` — ESM + CJS + DTS + browser bundles
- [x] `npm outdated` — 0 actionable outdated packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)