### PR TITLE
ci: update integration test matrix to PW 1.60

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        playwright-version: ['1.57.0', '1.59.0']
+        playwright-version: ['1.57.0', '1.60.0']
         include:
           - playwright-version: 'next'
             canary: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        playwright-version: ['1.57.0', '1.59.0']
+        playwright-version: ['1.57.0', '1.60.0']
     env:
       SAP_CLOUD_BASE_URL: ${{ secrets.SAP_CLOUD_BASE_URL }}
       SAP_CLOUD_USERNAME: ${{ secrets.SAP_CLOUD_USERNAME }}


### PR DESCRIPTION
## Summary
- Update Playwright integration test matrix from `1.59.0` to `1.60.0` in canary and release workflows
- Aligns CI with the v1.3.0 Playwright 1.60 support

## Test plan
- [ ] CI passes with updated matrix
- [ ] Canary publish succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)