### PR TITLE
feat(docs): add second demo video to carousel and demo page

### DIFF
--- a/docs/src/pages/demo.tsx
+++ b/docs/src/pages/demo.tsx
@@ -24,6 +24,7 @@ function DemoStep({ step, title, desc }: { step: string; title: string; desc: st
 
 const VIDEOS = [
   { id: 'Q1EqVPy4-QQ', title: 'Praman — Getting Started' },
+  { id: 'mHsYAZZWnSw', title: 'Praman — Video 2' },
 ];
 
 function VideoSeries(): ReactNode {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -559,7 +559,7 @@ const SLIDES: CarouselSlide[] = [
     tags: ['AI Agents', 'Test Engineers', 'Business Analysts'],
     primaryCta: { label: 'View Personas', to: '/personas' },
     secondaryCta: { label: 'Documentation', to: '/docs' },
-    Visual: PersonaSVG,
+    Visual: () => <VideoEmbed videoId="mHsYAZZWnSw" title="Praman — Video 2" />,
   },
   {
     id: 'claude-code',


### PR DESCRIPTION
## Summary
- Add second YouTube video (`mHsYAZZWnSw`) to landing page carousel slide 2 (replaces PersonaSVG)
- Add same video to `/demo` page VIDEOS array (renders in the video grid below the featured video)

## Test plan
- [x] Docusaurus build passes
- [x] All 4476 unit tests pass
- [ ] Verify landing page carousel slide 2 shows video
- [ ] Verify `/demo` page shows both videos (featured + grid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)