### PR TITLE
feat(docs): add third demo video and fix card alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Describe your business process; AI agents deliver production-ready test scripts.
 
 > **[Comparing SAP test automation tools →](https://mrkanitkar.github.io/playwright-praman/blog/2026/04/02/sap-test-automation-comparison)**
 
+[![Watch the demo](https://img.youtube.com/vi/RFRXkVi2pho/maxresdefault.jpg)](https://youtu.be/RFRXkVi2pho)
+
 ## Who is Praman for?
 
 | Stakeholder                                                | Value                                                                                                    |

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -598,6 +598,7 @@ div[class*='announcementBar'] {
   background: #1a1a2e;
   border-radius: 8px;
   padding: 0.7rem 1rem;
+  margin-top: auto;
   margin-bottom: 1rem;
 }
 

--- a/docs/src/pages/demo.tsx
+++ b/docs/src/pages/demo.tsx
@@ -25,6 +25,7 @@ function DemoStep({ step, title, desc }: { step: string; title: string; desc: st
 const VIDEOS = [
   { id: 'Q1EqVPy4-QQ', title: 'Praman — Getting Started' },
   { id: 'mHsYAZZWnSw', title: 'Praman — Video 2' },
+  { id: 'RFRXkVi2pho', title: 'Praman — Video 3' },
 ];
 
 function VideoSeries(): ReactNode {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1692,6 +1692,9 @@ export default function Home(): ReactNode {
         <HeroCarousel />
         <GlanceSection />
         <UseCaseCards />
+        <section style={{ padding: '3rem 2rem 2rem', maxWidth: 900, margin: '0 auto' }}>
+          <VideoEmbed videoId="RFRXkVi2pho" title="Praman — SAP Test Automation Demo" />
+        </section>
         <AgentFlowSection />
         <ReportsSection />
         <div


### PR DESCRIPTION
## Summary
- Add YouTube video `RFRXkVi2pho` to the `/demo` page as a third video in the series
- Add the same video to the homepage, positioned before the "How It Works" section (max-width 900px, responsive 16:9 embed)
- Fix use-case card alignment: install code boxes now stay bottom-aligned across all 5 columns via `margin-top: auto`

## Test plan
- [ ] Verify `/demo` page shows all 3 videos stacked vertically with equal size
- [ ] Verify homepage shows the new video between the use-case cards and "How It Works" section
- [ ] Verify use-case card install boxes are bottom-aligned across all columns
- [ ] Check responsive behavior on mobile viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)