### PR TITLE
fix: migrate remaining ElementRegistry direct-access to sap.ui.require

### DIFF
--- a/src/ai/bulk-discovery.ts
+++ b/src/ai/bulk-discovery.ts
@@ -401,9 +401,8 @@ function browserDiscoverControls(args: BrowserArgs): {
   const sapWindow = window as any;
   let elementsMap: Record<string, unknown> = {};
   try {
-    const elementRegistry = (sapWindow.sap?.ui?.core?.ElementRegistry ?? undefined) as
-      | { all?: () => Record<string, unknown> }
-      | undefined;
+    const elementRegistry = (sapWindow.sap?.ui?.require?.('sap/ui/core/ElementRegistry') ??
+      undefined) as { all?: () => Record<string, unknown> } | undefined;
     if (typeof elementRegistry?.all === 'function') {
       elementsMap = elementRegistry.all();
     } else {

--- a/src/bridge/browser-scripts/find-control-fn.ts
+++ b/src/bridge/browser-scripts/find-control-fn.ts
@@ -383,9 +383,16 @@ function getElementRegistry(): UI5Record | undefined {
   const core = ui['core'] as UI5Record | undefined;
   if (core === undefined) return undefined;
   const element = core['Element'] as UI5Record | undefined;
-  return element !== undefined
-    ? (element['registry'] as UI5Record | undefined)
-    : (core['ElementRegistry'] as UI5Record | undefined);
+  if (element !== undefined) {
+    const registry = element['registry'] as UI5Record | undefined;
+    if (registry !== undefined) return registry;
+  }
+  const requireFn = ui['require'] as ((mod: string) => UI5Record | null) | undefined;
+  if (typeof requireFn === 'function') {
+    const er = requireFn('sap/ui/core/ElementRegistry');
+    if (er !== null) return er;
+  }
+  return undefined;
 }
 
 /** Checks whether a control's ID matches via exact or suffix match. */

--- a/tests/seeds/sap-seed.spec.ts
+++ b/tests/seeds/sap-seed.spec.ts
@@ -136,7 +136,7 @@ test.describe('SAP Agent Seed', () => {
           // Method 2: Element.registry.all() — modern control enumeration (UI5 >= 1.67)
           const registry =
             (window as any).sap?.ui?.core?.Element?.registry ??
-            (window as any).sap?.ui?.core?.ElementRegistry;
+            (window as any).sap?.ui?.require?.('sap/ui/core/ElementRegistry');
           const allControls = registry?.all ? Object.values(registry.all()) : [];
           if (allControls.length > 0) {
             return allControls.length;
@@ -190,7 +190,7 @@ test.describe('SAP Agent Seed', () => {
           // Method 2: Element.registry.all() — modern control enumeration (UI5 >= 1.67)
           const reg =
             (window as any).sap?.ui?.core?.Element?.registry ??
-            (window as any).sap?.ui?.core?.ElementRegistry;
+            (window as any).sap?.ui?.require?.('sap/ui/core/ElementRegistry');
           const allControls = reg?.all ? (Object.values(reg.all()) as unknown[]) : [];
           if (allControls.length > 0) {
             totalControls = allControls.length;


### PR DESCRIPTION
## Summary

Follow-up to #152 — three files were missed and still used the old `sap.ui.core.ElementRegistry` global accessor removed in UI5 1.136+:

- **`src/ai/bulk-discovery.ts`** (critical) — AI discovery entry point used `sap?.ui?.core?.ElementRegistry` directly; TSDoc already claimed `sap.ui.require()` but runtime code didn't match
- **`src/bridge/browser-scripts/find-control-fn.ts`** — `getElementRegistry()` fallback path used `core['ElementRegistry']` property access
- **`tests/seeds/sap-seed.spec.ts`** (2 sites) — seed control counting fallback used `sap?.ui?.core?.ElementRegistry`

All three now use `sap.ui.require('sap/ui/core/ElementRegistry')` consistent with the rest of the codebase.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run test:unit` — 4476 tests pass
- [x] `npm run lint` — zero errors, zero warnings
- [x] `npm run build` — ESM + CJS + browser bundles succeed
- [x] `grep` confirms zero remaining direct-access patterns in `src/`, `scripts/`, `tests/`
- [ ] Smoke test on UI5 1.136+ system (control discovery returns controls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)