### PR TITLE
docs: add v1.3.4 release notes and blog post

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,6 +1,6 @@
 
-# Abbreviated identifiers (proxy API)
 # AI / LLM
+# Abbreviated identifiers (proxy API)
 # Auth / security tokens
 # British English variants
 # Build & tooling
@@ -19,14 +19,44 @@
 # TypeScript / code terms
 # VS Code extension IDs
 # XPath error codes
-agentic
 Aggs
+BLACKLIST
+BatchSpanProcessor
+Behaviour
+Codegen
+EACCES
+EBELN
+Embedder
+INTERACTABLE
+JSESSIONID
+KUNNR
+Kanitkar
+Kbps
+MeterProvider
+Microbenchmarks
+Millis
+NodeSDK
+Outb
+PWDEBUG
+Pydantic
+QTEST
+SAPGUI
+SDET
+SESSIONID
+SOGE
+Segoe
+Signavio
+Sxxxxxxxx
+TESTRAIL
+TESTUSER
+TracerProvider
+Visio
+WDIO
+XPST
+agentic
 apos
 appendable
 attw
-BatchSpanProcessor
-Behaviour
-BLACKLIST
 blacklisted
 blocklist
 camelcase
@@ -36,7 +66,6 @@ certuser
 checkmark
 cicd
 cidx
-Codegen
 combinators
 commitizen
 commitlint
@@ -57,10 +86,7 @@ dhikraft
 dlgs
 docusaurus
 domcontentloaded
-EACCES
 eamodio
-EBELN
-Embedder
 endo
 errorlens
 esbenp
@@ -79,28 +105,21 @@ hermetic
 initialisation
 initialise
 initialised
-INTERACTABLE
 introspectable
 introspection
 jaeger
-JSESSIONID
-Kanitkar
-Kbps
 kebabcase
 kohler
-KUNNR
 langchain
 langgraph
+linkify
 lintstagedrc
 llms
 llmstxt
 maheshwar
 mdlint
-MeterProvider
 mgmt
-Microbenchmarks
 microtasks
-Millis
 mmpur
 modelcontextprotocol
 modularizes
@@ -113,7 +132,6 @@ networkidle
 noassert
 nocol
 nodenext
-NodeSDK
 normalised
 npmjs
 opencode
@@ -121,7 +139,6 @@ opentelemetry
 optimised
 otel
 otlp
-Outb
 pageobject
 parallelizable
 pclick
@@ -136,12 +153,9 @@ preuninstall
 provenance
 pstep
 ptest
-PWDEBUG
 pwtest
 pwuser
-Pydantic
 pytest
-QTEST
 readymade
 recordreplay
 recordreply
@@ -151,15 +165,12 @@ resumability
 rgba
 roundtrips
 sapbw
-SAPGUI
 sapmbutton
 sbom
 scaffolder
 screencast
 screencasts
 scriptable
-SDET
-Segoe
 semver
 serialisable
 serialisation
@@ -168,25 +179,19 @@ serialiser
 serialises
 serializability
 serializable
-SESSIONID
-Signavio
+sigstore
 smol
-SOGE
 stabilise
 stabilised
 stringifying
 subdirs
 subpaths
 summarising
-Sxxxxxxxx
 testlib
 testng
-TESTRAIL
-TESTUSER
 thenable
 toequal
 totp
-TracerProvider
 tsup
 tsyringe
 unminified
@@ -197,20 +202,17 @@ upvote
 usernamehw
 valuehelp
 viewports
-Visio
 vitems
 vitest
 vkey
 vtext
 waitforui
 wdi5
-WDIO
 winjs
 workitem
 worklist
 xclip
 xdist
-XPST
 xsel
 xyznonexistent
 yoavbls

--- a/docs/blog/2026-07-05-v1-3-4-release.md
+++ b/docs/blog/2026-07-05-v1-3-4-release.md
@@ -1,0 +1,211 @@
+---
+title: 'Praman 1.3.4: Playwright 1.61, Web Storage Fixture, Native Timestamps, and Security Hardening'
+authors: [maheshwar]
+tags: [release, v1.3.4, playwright-1.61, web-storage, security, praman]
+date: 2026-07-05
+---
+
+# Praman 1.3.4: Playwright 1.61, Web Storage Fixture, Native Timestamps, and Security Hardening
+
+**Praman 1.3.4** is now available on npm. This release brings **Playwright 1.61** support with 5 new feature flags, a **typed Web Storage fixture** for localStorage/sessionStorage operations, **native screencast frame timestamps**, security fixes resolving 5 vulnerabilities, and CI hardening with floor+ceiling Playwright validation.
+
+<!-- truncate -->
+
+## What changed since v1.3.3
+
+Ten commits landed between v1.3.3 and v1.3.4, covering Playwright 1.61 compatibility, a new Web Storage fixture, screencast precision improvements, security vulnerability resolution, and CI pipeline enhancements.
+
+---
+
+## Playwright 1.61 — 5 New Feature Flags
+
+Praman now detects and gates **Playwright 1.61** APIs via 5 new feature flags in the internal `PlaywrightFeatures` interface:
+
+| Feature flag             | API gated                              | What it enables                                    |
+| ------------------------ | -------------------------------------- | -------------------------------------------------- |
+| `hasWebAuthnCredentials` | `browserContext.credentials`           | WebAuthn credential management for passkey testing |
+| `hasWebStorageAPI`       | `page.localStorage` / `sessionStorage` | Typed access to browser storage without evaluate() |
+| `hasSoftPoll`            | `expect.soft.poll()`                   | Soft assertion polling for non-blocking checks     |
+| `hasScreencastTimestamp` | Native `onFrame` timestamps            | Microsecond-precise frame timing from the browser  |
+| `hasVideoRetainModes`    | `on-all-retries`, `retain-on-*`        | Granular video recording retention strategies      |
+
+All flags are auto-detected at runtime. On Playwright < 1.61, all return `false` with zero behavior change. The peer dependency range remains `">=1.57.0 <2.0.0"` — Playwright 1.61 already falls within range, so no `package.json` changes are needed.
+
+---
+
+## Web Storage Fixture
+
+The headline feature of this release: a typed fixture for seeding and inspecting browser storage without `page.evaluate()`:
+
+```typescript
+import { test } from 'playwright-praman';
+
+test('configure app via localStorage', async ({ webStorage }) => {
+  // Bulk seed before navigation
+  await webStorage.localStorage.seed({
+    theme: 'dark',
+    language: 'en',
+    featureFlags: JSON.stringify({ newUI: true }),
+  });
+
+  // Individual operations
+  await webStorage.sessionStorage.setItem('sessionToken', 'abc123');
+  const token = await webStorage.sessionStorage.getItem('sessionToken');
+
+  // Inspection
+  const allLocal = await webStorage.localStorage.items(); // Record<string, string>
+  const count = await webStorage.localStorage.size(); // number
+
+  // Cleanup
+  await webStorage.localStorage.clear();
+});
+```
+
+### API Surface
+
+Both `webStorage.localStorage` and `webStorage.sessionStorage` expose the same `WebStorageHelper` interface:
+
+| Method       | Signature                                            | Description                 |
+| ------------ | ---------------------------------------------------- | --------------------------- |
+| `setItem`    | `(key: string, value: string) => Promise<void>`      | Set a single key-value pair |
+| `getItem`    | `(key: string) => Promise<string \| null>`           | Get value by key            |
+| `removeItem` | `(key: string) => Promise<void>`                     | Remove a single key         |
+| `items`      | `() => Promise<Record<string, string>>`              | Get all entries as a record |
+| `seed`       | `(entries: Record<string, string>) => Promise<void>` | Bulk-set multiple pairs     |
+| `clear`      | `() => Promise<void>`                                | Clear all entries           |
+| `size`       | `() => Promise<number>`                              | Count of stored entries     |
+
+### Feature Gate
+
+The fixture is gated behind `hasWebStorageAPI`. On Playwright < 1.61, it throws a `PramanError` with code `ERR_COMPAT_FEATURE_UNAVAILABLE` and actionable suggestions:
+
+```
+PramanError: Web Storage fixture requires Playwright 1.61+
+  Suggestions:
+    - Upgrade Playwright: npm install @playwright/test@latest
+    - Use page.evaluate() as a fallback for older versions
+```
+
+### When to Use
+
+Use the Web Storage fixture instead of `page.evaluate()` when you need to:
+
+- **Seed configuration** before navigating to an SAP Fiori app (theme, language, feature flags)
+- **Inject tokens** for apps that read auth state from localStorage
+- **Verify storage side effects** after user interactions (form drafts, preferences)
+- **Clear storage** between test steps for isolation
+
+The typed API catches key/value type errors at compile time and the fixture integrates with Praman's test lifecycle (placed after auth, before navigation in the fixture chain).
+
+---
+
+## Native Screencast Frame Timestamps
+
+The screencast fixture now uses **native browser-provided frame timestamps** on Playwright 1.61+. Previously, all frame timestamps were synthetic (`Date.now() - startTime`). The native timestamps come directly from the browser's rendering pipeline with microsecond alignment.
+
+**Impact:** More precise timing for frame-level analysis, video synchronization, and performance measurement. The `ScreencastFrame.timestamp` type and semantics are unchanged (milliseconds since recording start) — this is a transparent precision improvement.
+
+**Backward compatible:** Falls back to synthetic timestamps on Playwright < 1.61.
+
+---
+
+## Security Hardening
+
+This release resolves **5 security vulnerabilities**:
+
+| Package      | Severity | Issue                                | Fix                      |
+| ------------ | -------- | ------------------------------------ | ------------------------ |
+| `vite`       | High     | Windows `server.fs.deny` bypass      | Upgraded 8.0.6 → 8.1.3   |
+| `esbuild`    | High     | Arbitrary file read on Windows       | npm override → 0.28.1    |
+| `undici`     | High     | 7 advisories (TLS, WebSocket, SOCKS) | Upgraded 7.24.7 → 7.28.0 |
+| `linkify-it` | High     | Quadratic complexity DoS             | Upgraded 5.0.0 → 5.0.2   |
+| `tar`        | Moderate | File smuggling via PAX headers       | Upgraded 7.5.15 → 7.5.16 |
+
+The remaining 8 alerts are all in `@ui5/mcp-server`'s transitive `@sigstore/core` dependency chain — no fix is available until SAP publishes an updated package.
+
+---
+
+## CI Pipeline: Floor + Ceiling Validation
+
+The CI workflow now validates Playwright compatibility at both boundaries:
+
+```
+playwright-floor  (1.57.0)  → build + full test suite pass
+playwright-ceiling (latest) → build + full test suite + verify 1.61 flags active
+```
+
+This ensures every commit maintains backward compatibility with the minimum supported Playwright version while also verifying that new feature flags activate correctly on the latest release.
+
+Additional CI improvements:
+
+- `actions/checkout` upgraded v5 → v7 (security hardening for `pull_request_target`)
+- `github/codeql-action` upgraded to 4.36.2
+
+---
+
+## New Error Category: Compat
+
+A new error category for feature-availability errors:
+
+```typescript
+throw new PramanError({
+  code: ErrorCode.ERR_COMPAT_FEATURE_UNAVAILABLE,
+  message: 'Web Storage fixture requires Playwright 1.61+',
+  attempted: 'Access page.localStorage / page.sessionStorage API',
+  retryable: false,
+  suggestions: [
+    'Upgrade Playwright: npm install @playwright/test@latest',
+    'Use page.evaluate() as a fallback for older versions',
+  ],
+});
+```
+
+This brings the total to **78 error codes** across **18 categories**. Every Praman error includes structured metadata: `code`, `attempted`, `retryable`, and `suggestions[]` — making errors actionable for both humans and AI agents.
+
+---
+
+## Dependency Updates
+
+| Category        | Packages                                                 |
+| --------------- | -------------------------------------------------------- |
+| **Playwright**  | `@playwright/test` 1.60.0 → 1.61.1                       |
+| **AI/LLM**      | `@anthropic-ai/sdk` 0.100.1 → 0.110.0                    |
+| **CLI**         | `commander` 14.0.3 → 15.0.0                              |
+| **Testing**     | `vitest` + `@vitest/coverage-v8` → 4.1.9                 |
+| **Telemetry**   | `@opentelemetry/*` suite upgraded                        |
+| **SAP tooling** | `@ui5/mcp-server` 0.2.12 → 0.2.14                        |
+| **Build**       | `esbuild` 0.28.0 → 0.28.1 (override for tsup nested dep) |
+| **Linting**     | `@commitlint/cli` 21.0.2 → 21.2.0                        |
+
+35 dev dependencies upgraded in total.
+
+---
+
+## Upgrade Guide
+
+```bash
+npm install playwright-praman@1.3.4
+```
+
+No configuration changes required. All new features are either:
+
+- Auto-detected (feature flags activate when PW 1.61+ is detected)
+- Opt-in (Web Storage fixture only activates when `webStorage` is destructured in a test)
+
+If you're on Playwright < 1.61, everything continues to work unchanged. To access the Web Storage fixture, upgrade Playwright:
+
+```bash
+npm install @playwright/test@latest
+```
+
+---
+
+## What's Next
+
+- **WebAuthn credentials fixture** — passkey/FIDO2 testing for SAP systems with biometric auth
+- **`expect.soft.poll()` wrapper** — non-blocking assertions that retry without failing the test
+- **Playwright 1.62 tracking** — compat layer ready for the next release cycle
+
+---
+
+_Praman 1.3.4 is available on [npm](https://www.npmjs.com/package/playwright-praman). Report issues on [GitHub](https://github.com/mrkanitkar/playwright-praman/issues)._

--- a/docs/docs/release-notes.md
+++ b/docs/docs/release-notes.md
@@ -6,12 +6,108 @@ description: "What's new in playwright-praman — version history, new features,
 keywords:
   - playwright praman release notes
   - sap ui5 test automation changelog
+  - playwright 1.61 support
   - playwright 1.60 support
+  - web storage fixture
   - typescript 7 playwright
   - typescript 6 playwright
 ---
 
 # Release Notes
+
+## Version 1.3.4
+
+_Released: July 2026 · [npm](https://www.npmjs.com/package/playwright-praman/v/1.3.4) · [GitHub](https://github.com/mrkanitkar/playwright-praman/releases/tag/playwright-praman-v1.3.4)_
+
+### 🎭 Playwright 1.61 Support — 5 New Feature Flags
+
+Praman now detects and gates **Playwright 1.61** APIs via 5 new feature flags, auto-detected at runtime:
+
+| Feature flag             | API gated                              | What it enables                                    |
+| ------------------------ | -------------------------------------- | -------------------------------------------------- |
+| `hasWebAuthnCredentials` | `browserContext.credentials`           | WebAuthn credential management for passkey testing |
+| `hasWebStorageAPI`       | `page.localStorage` / `sessionStorage` | Typed access to browser storage without evaluate() |
+| `hasSoftPoll`            | `expect.soft.poll()`                   | Soft assertion polling for non-blocking checks     |
+| `hasScreencastTimestamp` | Native `onFrame` timestamps            | Microsecond-precise frame timing from the browser  |
+| `hasVideoRetainModes`    | `on-all-retries`, `retain-on-*`        | Granular video recording retention strategies      |
+
+All flags return `false` on Playwright < 1.61 — zero behavior change for existing users.
+
+**Peer dependency unchanged:** `"@playwright/test": ">=1.57.0 <2.0.0"` — Playwright 1.61 already falls within range.
+
+### 💾 New: Web Storage Fixture
+
+A typed fixture for seeding and inspecting browser storage — no more `page.evaluate()` for localStorage/sessionStorage operations:
+
+```typescript
+import { test } from 'playwright-praman';
+
+test('seed localStorage before navigation', async ({ webStorage }) => {
+  await webStorage.localStorage.seed({ theme: 'dark', lang: 'en' });
+  await webStorage.localStorage.setItem('token', 'abc123');
+
+  const all = await webStorage.sessionStorage.items();
+  const count = await webStorage.localStorage.size();
+  await webStorage.localStorage.clear();
+});
+```
+
+**API surface:** `setItem`, `getItem`, `removeItem`, `items`, `seed`, `clear`, `size` — available on both `webStorage.localStorage` and `webStorage.sessionStorage`.
+
+**Feature-gated:** Throws `ERR_COMPAT_FEATURE_UNAVAILABLE` with clear upgrade guidance on Playwright < 1.61.
+The error includes suggestions for both upgrading and using `page.evaluate()` as a fallback.
+
+### 📹 Native Screencast Frame Timestamps
+
+The screencast fixture now uses **native browser-provided frame timestamps** (microsecond-aligned)
+on Playwright 1.61+, instead of synthetic `Date.now()` timestamps. This improves timing precision
+for frame-level analysis without any API changes — `ScreencastFrame.timestamp` remains `number`
+(milliseconds since recording start).
+
+Falls back to synthetic timestamps on Playwright < 1.61.
+
+### 🛡️ Security Fixes
+
+Resolved **5 vulnerabilities** through direct upgrades and npm overrides:
+
+| Package      | From   | To     | Severity | Fix type       |
+| ------------ | ------ | ------ | -------- | -------------- |
+| `vite`       | 8.0.6  | 8.1.3  | High     | audit fix      |
+| `tar`        | 7.5.15 | 7.5.16 | Moderate | audit fix      |
+| `esbuild`    | 0.27.7 | 0.28.1 | High     | npm override   |
+| `undici`     | 7.24.7 | 7.28.0 | High     | docs workspace |
+| `linkify-it` | 5.0.0  | 5.0.2  | High     | docs workspace |
+
+Remaining 8 vulnerabilities are all in `@ui5/mcp-server`'s transitive `@sigstore/core` chain — no fix available until SAP publishes an update.
+
+### 🔧 New Error Category: Compat
+
+Added `ERR_COMPAT_FEATURE_UNAVAILABLE` error code under a new **Compat** error category. Used when a fixture requires a Playwright version newer than what's installed. The error includes specific upgrade instructions and fallback suggestions.
+
+Total: **78 error codes** across **18 categories** (up from 77/17).
+
+### ⚡ CI Improvements
+
+- **Playwright ceiling test**: new CI job installs `@playwright/test@latest` and explicitly verifies PW 1.61 feature flags are active
+- **actions/checkout** upgraded v5 → v7 across all workflows
+- **github/codeql-action** upgraded to 4.36.2
+- **Floor + ceiling validation**: CI now validates both minimum (1.57.0) and latest Playwright compatibility on every push
+
+### 📦 Dependency Updates
+
+**Dev dependencies (35 packages upgraded):**
+
+- `@playwright/test` 1.60.0 → 1.61.1
+- `@anthropic-ai/sdk` 0.100.1 → 0.110.0
+- `commander` 14.0.3 → 15.0.0
+- `@commitlint/cli` 21.0.2 → 21.2.0
+- `vitest` + `@vitest/coverage-v8` → 4.1.9
+- `@opentelemetry/*` suite updated
+- `@ui5/mcp-server` 0.2.12 → 0.2.14
+
+**Upgrade:** `npm install playwright-praman@1.3.4` — no config changes needed.
+
+---
 
 ## Version 1.3.3
 


### PR DESCRIPTION
## Summary

- Added v1.3.4 section to `docs/docs/release-notes.md` covering all changes since v1.3.3
- Created blog post at `docs/blog/2026-07-05-v1-3-4-release.md` with detailed coverage of:
  - Playwright 1.61 support (5 new feature flags)
  - Web Storage fixture (typed localStorage/sessionStorage API)
  - Native screencast frame timestamps
  - Security hardening (5 CVEs resolved)
  - CI floor+ceiling Playwright validation
  - New Compat error category (78 codes / 18 categories)
  - 35 dependency upgrades
- Added `linkify` and `sigstore` to cspell dictionary

## Test plan

- [x] markdownlint passes on both files
- [x] cspell passes (0 issues)
- [x] All 4575 unit tests pass
- [x] Build succeeds (ESM + CJS)
- [ ] Docusaurus builds successfully (docs-check CI job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)