### PR TITLE
fix: resolve Playwright 1.57 floor build and Windows test failures

### DIFF
--- a/src/fixtures/screencast-fixture.ts
+++ b/src/fixtures/screencast-fixture.ts
@@ -60,7 +60,7 @@
 import type { Buffer } from 'node:buffer';
 
 import { test as base } from '@playwright/test';
-import type { Page, Screencast } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import type { Logger } from 'pino';
 
 import { hasFeature } from '#core/compat/index.js';
@@ -257,11 +257,16 @@ export interface ScreencastWorkerDeps {
  * Minimal safe structural accessor for the Playwright Screencast object.
  *
  * @remarks
- * Used only to check for the presence of methods at runtime without
- * extending the actual `Screencast` interface (which would trigger
- * `TS2430` if signatures differ from the real Playwright types).
+ * Defined structurally so that the module compiles against Playwright
+ * versions that predate the Screencast type export (prior to 1.59).
+ * Runtime availability is gated by feature flags.
  */
-type ScreencastApi = Pick<Screencast, 'showChapter' | 'showActions' | 'start' | 'stop'>;
+interface ScreencastApi {
+  showChapter(title: string): void;
+  showActions(options?: ShowActionsOptions): Promise<void> | void;
+  start(options?: Record<string, unknown>): Promise<void>;
+  stop(): Promise<void>;
+}
 
 // ── Fixture definition ──────────────────────────────────────────────────────
 
@@ -461,7 +466,7 @@ export const screencastTest = base.extend<ScreencastFixtures, ScreencastWorkerDe
       clearHighlightState(page);
       if (hasFeature('hasLocatorHighlightStyle')) {
         try {
-          await page.hideHighlight();
+          await (page as Page & { hideHighlight(): Promise<void> }).hideHighlight();
         } catch (error: unknown) {
           log.debug({ err: error }, 'page.hideHighlight() failed during teardown (non-fatal)');
         }

--- a/src/proxy/control-proxy.ts
+++ b/src/proxy/control-proxy.ts
@@ -370,8 +370,7 @@ async function handleReturn(
     }
     case 'newElement': {
       const ref = result.value as
-        | { readonly id: string; readonly controlType?: string }
-        | undefined;
+        { readonly id: string; readonly controlType?: string } | undefined;
       if (ref === undefined) return undefined;
       return createControlProxy({
         id: ref.id,
@@ -440,8 +439,7 @@ async function resolveControlDomId(state: ControlProxyState): Promise<string | n
       const bridge = Reflect.get(window, bridgeNs) as Record<string, unknown> | undefined;
       if (bridge === undefined) return null;
       const getById = bridge['getById'] as
-        | ((id: string) => Record<string, unknown> | null)
-        | undefined;
+        ((id: string) => Record<string, unknown> | null) | undefined;
       if (getById === undefined) return null;
       const ctrl = getById(controlId);
       if (ctrl === null) return null;
@@ -470,13 +468,14 @@ async function highlightForInteraction(state: ControlProxyState): Promise<void> 
   const hl = getHighlightState(state.page);
   if (hl?.enabled !== true || !hasFeature('hasLocatorHighlightStyle')) return;
   try {
-    await state.page.hideHighlight();
+    await (state.page as Page & { hideHighlight(): Promise<void> }).hideHighlight();
     const domId = await resolveControlDomId(state);
     if (domId !== null) {
       const selector = `[id="${domId.replaceAll(/(["\\])/gu, '\\$1')}"]`;
-      const options: { style?: string | Record<string, string | number> } = {};
-      if (hl.style !== undefined) options.style = hl.style;
-      await state.page.locator(selector).highlight(options);
+      const locator = state.page.locator(selector) as Locator & {
+        highlight(opts?: { style?: string | Record<string, string | number> }): Promise<void>;
+      };
+      await locator.highlight(hl.style !== undefined ? { style: hl.style } : undefined);
     }
   } catch {
     // best-effort — highlighting must never break an interaction
@@ -515,8 +514,7 @@ function resolveKnownProperty(
             const bridge = Reflect.get(window, bridgeNs) as Record<string, unknown> | undefined;
             if (bridge === undefined) return null;
             const getById = bridge['getById'] as
-              | ((id: string) => Record<string, unknown> | null)
-              | undefined;
+              ((id: string) => Record<string, unknown> | null) | undefined;
             if (getById === undefined) return null;
             const ctrl = getById(controlId);
             if (ctrl === null) return null;
@@ -579,8 +577,7 @@ function resolveKnownProperty(
             // eslint-disable-next-line sonarjs/no-duplicate-string -- self-contained browser function cannot reference Node-side constants
             if (bridge === undefined) throw new Error('Bridge not initialized');
             const getById = bridge['getById'] as
-              | ((id: string) => Record<string, unknown> | null)
-              | undefined;
+              ((id: string) => Record<string, unknown> | null) | undefined;
             // eslint-disable-next-line sonarjs/no-duplicate-string -- self-contained browser function cannot reference Node-side constants
             if (getById === undefined) throw new Error('Bridge getById not available');
             const ctrl = getById(controlId);
@@ -609,8 +606,7 @@ function resolveKnownProperty(
             const bridge = Reflect.get(window, bridgeNs) as Record<string, unknown> | undefined;
             if (bridge === undefined) return false;
             const getById = bridge['getById'] as
-              | ((id: string) => Record<string, unknown> | null)
-              | undefined;
+              ((id: string) => Record<string, unknown> | null) | undefined;
             if (getById === undefined) return false;
             const ctrl = getById(controlId);
             return ctrl !== null;
@@ -642,8 +638,7 @@ function resolveKnownProperty(
             const bridge = Reflect.get(window, bridgeNs) as Record<string, unknown> | undefined;
             if (bridge === undefined) throw new Error('Bridge not initialized');
             const getById = bridge['getById'] as
-              | ((id: string) => Record<string, unknown> | null)
-              | undefined;
+              ((id: string) => Record<string, unknown> | null) | undefined;
             if (getById === undefined) throw new Error('Bridge getById not available');
             const ctrl = getById(controlId);
             if (ctrl === null) throw new Error('Control not found: ' + controlId);
@@ -652,14 +647,11 @@ function resolveKnownProperty(
             const meta = getMetadata.call(ctrl);
             const getName = meta['getName'] as (() => string) | undefined;
             const getAllProperties = meta['getAllProperties'] as
-              | (() => Record<string, unknown>)
-              | undefined;
+              (() => Record<string, unknown>) | undefined;
             const getAllAggregations = meta['getAllAggregations'] as
-              | (() => Record<string, unknown>)
-              | undefined;
+              (() => Record<string, unknown>) | undefined;
             const getAllEvents = meta['getAllEvents'] as
-              | (() => Record<string, unknown>)
-              | undefined;
+              (() => Record<string, unknown>) | undefined;
             return {
               className: getName !== undefined ? getName.call(meta) : 'unknown',
               properties:
@@ -683,8 +675,7 @@ function resolveKnownProperty(
             const bridge = Reflect.get(window, bridgeNs) as Record<string, unknown> | undefined;
             if (bridge === undefined) throw new Error('Bridge not initialized');
             const getById = bridge['getById'] as
-              | ((id: string) => Record<string, unknown> | null)
-              | undefined;
+              ((id: string) => Record<string, unknown> | null) | undefined;
             if (getById === undefined) throw new Error('Bridge getById not available');
             const ctrl = getById(controlId);
             if (ctrl === null) throw new Error('Control not found: ' + controlId);
@@ -693,14 +684,11 @@ function resolveKnownProperty(
             const meta = getMetadata.call(ctrl);
             const getName = meta['getName'] as (() => string) | undefined;
             const getAllProperties = meta['getAllProperties'] as
-              | (() => Record<string, unknown>)
-              | undefined;
+              (() => Record<string, unknown>) | undefined;
             const getAllAggregations = meta['getAllAggregations'] as
-              | (() => Record<string, unknown>)
-              | undefined;
+              (() => Record<string, unknown>) | undefined;
             const getAllEvents = meta['getAllEvents'] as
-              | (() => Record<string, unknown>)
-              | undefined;
+              (() => Record<string, unknown>) | undefined;
             const methods = collectPrototypeMethods(ctrl);
             return {
               id: controlId,
@@ -754,8 +742,7 @@ function resolveKnownProperty(
             const bridge = Reflect.get(window, bridgeNs) as Record<string, unknown> | undefined;
             if (bridge === undefined) throw new Error('Bridge not initialized');
             const getById = bridge['getById'] as
-              | ((id: string) => Record<string, unknown> | null)
-              | undefined;
+              ((id: string) => Record<string, unknown> | null) | undefined;
             if (getById === undefined) throw new Error('Bridge getById not available');
             const ctrl = getById(controlId);
             if (ctrl === null) throw new Error('Control not found: ' + controlId);

--- a/tests/unit/cli/preuninstall.test.ts
+++ b/tests/unit/cli/preuninstall.test.ts
@@ -109,17 +109,16 @@ describe('cli/preuninstall', () => {
     });
 
     it('strips trailing forward slash from resolved root', () => {
-      // On posix, join produces /home/user/project/node_modules/playwright-praman
-      // The slash before node_modules remains after slicing at marker index
-      vi.spyOn(process, 'cwd').mockReturnValue(
-        '/home/user/project/node_modules/playwright-praman',
-      );
+      // Use join() so the marker matches the platform separator
+      const mockCwd = join('/home/user/project', 'node_modules', 'playwright-praman');
+      vi.spyOn(process, 'cwd').mockReturnValue(mockCwd);
 
       const result = resolveProjectRoot();
 
-      // Verify no trailing slash
-      expect(result).toBe('/home/user/project');
+      // Verify no trailing separator
+      expect(result).toBe(join('/home/user/project'));
       expect(result?.endsWith('/')).toBe(false);
+      expect(result?.endsWith('\\')).toBe(false);
     });
 
     it('strips trailing backslash from resolved root (Windows paths)', () => {
@@ -152,7 +151,11 @@ describe('cli/preuninstall', () => {
       );
 
       const fakeFiles = [
-        { relativePath: 'playwright.config.ts', category: 'config' as const, label: 'Playwright config' },
+        {
+          relativePath: 'playwright.config.ts',
+          category: 'config' as const,
+          label: 'Playwright config',
+        },
         { relativePath: 'praman.config.ts', category: 'config' as const, label: 'Praman config' },
       ];
       mockGetScaffoldedFiles.mockReturnValue(fakeFiles);
@@ -187,10 +190,10 @@ describe('cli/preuninstall', () => {
       expect(loggerMod.logWarn).toHaveBeenCalledWith(
         expect.stringContaining('Moving 2 Praman scaffolded file(s)'),
       );
-      expect(loggerMod.logWarn).toHaveBeenCalledWith(expect.stringContaining('playwright.config.ts'));
-      expect(loggerMod.logSuccess).toHaveBeenCalledWith(
-        expect.stringContaining('2 of 2'),
+      expect(loggerMod.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('playwright.config.ts'),
       );
+      expect(loggerMod.logSuccess).toHaveBeenCalledWith(expect.stringContaining('2 of 2'));
     });
 
     it('does nothing when project root cannot be resolved', async () => {
@@ -296,7 +299,11 @@ describe('cli/preuninstall', () => {
       );
 
       const fakeFiles = [
-        { relativePath: '.vscode/settings.json', category: 'ide' as const, label: 'VS Code settings' },
+        {
+          relativePath: '.vscode/settings.json',
+          category: 'ide' as const,
+          label: 'VS Code settings',
+        },
       ];
 
       vi.resetModules();
@@ -322,7 +329,9 @@ describe('cli/preuninstall', () => {
         setTimeout(resolve, 50);
       });
 
-      expect(loggerMod.logWarn).toHaveBeenCalledWith(expect.stringContaining('.vscode/settings.json'));
+      expect(loggerMod.logWarn).toHaveBeenCalledWith(
+        expect.stringContaining('.vscode/settings.json'),
+      );
     });
 
     it('logs preservation message after successful move', async () => {
@@ -332,7 +341,11 @@ describe('cli/preuninstall', () => {
       );
 
       const fakeFiles = [
-        { relativePath: 'playwright.config.ts', category: 'config' as const, label: 'Playwright config' },
+        {
+          relativePath: 'playwright.config.ts',
+          category: 'config' as const,
+          label: 'Playwright config',
+        },
       ];
 
       vi.resetModules();


### PR DESCRIPTION
## Summary

- Replace `import type { Screencast }` with a structural interface so DTS builds compile on PW < 1.59
- Cast `page.hideHighlight()` and `locator.highlight()` to avoid type errors on PW < 1.58
- Fix preuninstall test to use platform-aware paths via `join()` (was hardcoding Unix separators)

These three failures were introduced in PR #182 and appeared on both the `ci.yml` Playwright Floor job and Windows unit test matrix.

## Test plan

- [x] `npm run typecheck` passes with PW 1.57.0 installed
- [x] `npm run build` passes with PW 1.57.0 installed
- [x] `npm run typecheck` passes with PW 1.61.1 installed
- [x] All 4575 unit tests pass
- [x] Lint: 0 errors, 0 warnings
- [ ] CI: Playwright Floor (1.57.0) job passes
- [ ] CI: Windows unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)