### PR TITLE
fix: resolve CI failures and remove release-as pin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
     ".": {
-      "release-type": "node",
-      "release-as": "1.3.4"
+      "release-type": "node"
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,17 @@ export {
   VocabularyError,
 } from './core/errors/index.js';
 
+// ── Compat (version detection + feature flags) ────────────────────
+export type { PlaywrightVersion, PlaywrightFeatures } from './core/compat/index.js';
+export {
+  parsePlaywrightVersion,
+  detectFeatures,
+  getPlaywrightVersion,
+  getPlaywrightFeatures,
+  hasFeature,
+  assertMinVersion,
+} from './core/compat/index.js';
+
 // ── Utils ───────────────────────────────────────────────────────────
 export {
   DEFAULT_TIMEOUTS,

--- a/tests/unit/barrel/index-exports.test.ts
+++ b/tests/unit/barrel/index-exports.test.ts
@@ -54,10 +54,13 @@ describe('src/index.ts barrel', () => {
     expect(b['initTelemetry']).toBeUndefined();
   });
 
-  it('does NOT export compat internals', () => {
-    const b = barrel as Record<string, unknown>;
-    expect(b['getPlaywrightVersion']).toBeUndefined();
-    expect(b['hasFeature']).toBeUndefined();
+  it('exports compat version detection and feature flags', () => {
+    expect(typeof barrel.parsePlaywrightVersion).toBe('function');
+    expect(typeof barrel.detectFeatures).toBe('function');
+    expect(typeof barrel.getPlaywrightVersion).toBe('function');
+    expect(typeof barrel.getPlaywrightFeatures).toBe('function');
+    expect(typeof barrel.hasFeature).toBe('function');
+    expect(typeof barrel.assertMinVersion).toBe('function');
   });
 
   // ── Removed selector engine internals ───────────────────────────────

--- a/tests/unit/core/compat/playwright-compat.test.ts
+++ b/tests/unit/core/compat/playwright-compat.test.ts
@@ -166,12 +166,14 @@ describe('detectFeatures — 1.61 capabilities', () => {
 
 describe('hasFeature', () => {
   it('returns correct boolean for installed Playwright version', () => {
-    // Playwright 1.59.0 is installed — all features should be true
-    expect(hasFeature('hasClockAPI')).toBe(true);
-    expect(hasFeature('hasAriaSnapshot')).toBe(true);
-    expect(hasFeature('hasLocatorAssertions')).toBe(true);
-    expect(hasFeature('hasScreencastAPI')).toBe(true);
-    expect(hasFeature('hasLocatorNormalize')).toBe(true);
+    const version = getPlaywrightVersion();
+    const features = detectFeatures(version);
+
+    expect(hasFeature('hasClockAPI')).toBe(features.hasClockAPI);
+    expect(hasFeature('hasAriaSnapshot')).toBe(features.hasAriaSnapshot);
+    expect(hasFeature('hasLocatorAssertions')).toBe(features.hasLocatorAssertions);
+    expect(hasFeature('hasScreencastAPI')).toBe(features.hasScreencastAPI);
+    expect(hasFeature('hasLocatorNormalize')).toBe(features.hasLocatorNormalize);
   });
 });
 

--- a/tests/unit/modules/navigation-space.test.ts
+++ b/tests/unit/modules/navigation-space.test.ts
@@ -23,6 +23,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SpaceNavigationPage } from '../../../src/modules/navigation-space.js';
 
+import { hasFeature } from '#core/compat/index.js';
 import { NavigationError } from '#core/errors/navigation-error.js';
 import { DEFAULT_TIMEOUTS } from '#core/utils/constants.js';
 
@@ -190,10 +191,11 @@ describe('navigation-space module', () => {
         description: 'Supplier list',
       });
 
-      expect(page.getByRole).toHaveBeenCalledWith('link', {
-        name: 'Manage',
-        description: 'Supplier list',
-      });
+      const expectedRoleOptions = hasFeature('hasGetByRoleDescription')
+        ? { name: 'Manage', description: 'Supplier list' }
+        : { name: 'Manage' };
+
+      expect(page.getByRole).toHaveBeenCalledWith('link', expectedRoleOptions);
       expect(mockLocator.click).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
## Summary
- **Ceiling CI fix**: Export `parsePlaywrightVersion`, `detectFeatures`, and other compat functions from the main barrel (`src/index.ts`) so they're available in the CJS bundle (`dist/index.cjs`). The CI verification step was failing with `TypeError: parsePlaywrightVersion is not a function`.
- **Floor CI fix (2 tests)**: Make `hasFeature` test dynamically compare against installed PW version instead of hardcoding PW 1.59+ expectations. Guard navigation-space `description` test on `hasGetByRoleDescription` feature flag so it correctly expects the description to be dropped on PW < 1.60.
- **Release-please fix**: Remove `release-as: "1.3.4"` pin from `release-please-config.json` so the next release version is computed from conventional commits instead of being stuck at 1.3.4.

## Test plan
- [x] `npm run build` — CJS bundle now includes compat exports
- [x] CJS smoke test: `node -e "const { parsePlaywrightVersion, detectFeatures } = require('./dist/index.cjs')"` — passes
- [x] `npm run test:unit` — 4575/4575 passing, 0 failures
- [x] `npm run check:exports` — all sub-path exports green
- [x] Pre-push hooks passed (lint + typecheck + test:unit + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)