### PR TITLE
fix: align CodeQL action SHAs to resolve version mismatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,11 +29,11 @@ jobs:
         language: [javascript-typescript]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended
-      - uses: github/codeql-action/autobuild@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+      - uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
- Align all three CodeQL action steps (init, autobuild, analyze) to the same SHA (`8aad20d`)
- Previously init/autobuild pinned v4.36.1 while analyze pinned v4.36.2, causing: `Loaded a configuration file for version '4.36.1', but running version '4.36.2'`

## Test plan
- [x] CodeQL workflow should pass after merge (no code changes, only workflow SHA alignment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)