### PR TITLE
fix(ci): actually run agent-asset validation, and stop prettier corrupting it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
+      - run: npm run validate:agent-assets
       - run: npx cspell "src/**/*.ts" "docs/**/*.md" --no-progress
       - run: npx knip
       - run: npx markdownlint-cli2 "**/*.md" "#node_modules" "#docs/build" "#docs/node_modules"

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,10 @@ docs/build/
 !.prettierrc.json
 !.commitlintrc.json
 CHANGELOG.md
+
+# Generated distribution trees — must stay byte-identical to their .claude/
+# sources so validate:agent-assets can detect real drift. Reformatting these
+# creates permanent false drift (they are copies, not hand-edited files).
+agents/
+seeds/
+skills/praman-sap-cli/

--- a/agents/claude/praman-sap-planner-cli.md
+++ b/agents/claude/praman-sap-planner-cli.md
@@ -354,15 +354,15 @@ The agent (you) and the Praman fixture (`ui5`) operate in **different phases**:
 You explore the live SAP app using CLI commands. Praman fixtures (`ui5`, `sapAuth`) do NOT exist
 in agent context. Use raw SAP APIs via `run-code`:
 
-| Task             | CLI Command                    | SAP API                                               |
-| ---------------- | ------------------------------ | ----------------------------------------------------- |
+| Task             | CLI Command                    | SAP API                             |
+| ---------------- | ------------------------------ | ----------------------------------- |
 | Find controls    | `run-code "async page => ..."` | `sap.ui.require('sap/ui/core/ElementRegistry').get()` |
-| Read properties  | `run-code "async page => ..."` | `ctrl.getProperty('name')`                            |
-| Check visibility | `run-code "async page => ..."` | `ctrl.getVisible()`                                   |
-| Navigate         | `click e7` (snapshot ref)      | Click tiles/buttons                                   |
-| Take snapshot    | `snapshot --filename=snap.yml` | Visual verification                                   |
-| Fill form        | `fill e3 "value"`              | Fill input fields                                     |
-| Save auth        | `state-save sap-auth.json`     | Persist cookies + storage                             |
+| Read properties  | `run-code "async page => ..."` | `ctrl.getProperty('name')`          |
+| Check visibility | `run-code "async page => ..."` | `ctrl.getVisible()`                 |
+| Navigate         | `click e7` (snapshot ref)      | Click tiles/buttons                 |
+| Take snapshot    | `snapshot --filename=snap.yml` | Visual verification                 |
+| Fill form        | `fill e3 "value"`              | Fill input fields                   |
+| Save auth        | `state-save sap-auth.json`     | Persist cookies + storage           |
 
 ### Test Phase (Generated .spec.ts -- LATER)
 

--- a/agents/claude/prompts/praman-cli-coverage.md
+++ b/agents/claude/prompts/praman-cli-coverage.md
@@ -17,7 +17,6 @@ Read node_modules/playwright-praman/skills/playwright-praman-sap-testing/SKILL.m
 ```
 
 Wait for the planner to complete. It will produce:
-
 - `specs/{app}.plan.md` -- structured test plan
 - `tests/e2e/{app}/{app}-gold.spec.ts` -- gold-standard test
 
@@ -43,7 +42,6 @@ Read node_modules/playwright-praman/skills/playwright-praman-sap-testing/SKILL.m
 ```
 
 The healer will:
-
 1. Run tests with `--debug=cli` to pause at failures
 2. Attach and inspect page state via CLI
 3. Diagnose root causes (selector, timing, dialog, V2/V4)
@@ -66,7 +64,6 @@ Then verify overall compliance:
 - [ ] `npm run lint` passes
 
 Summarize results:
-
 - Total scenarios planned
 - Total tests generated
 - Tests passing on first run

--- a/agents/copilot/praman-sap-planner-cli.agent.md
+++ b/agents/copilot/praman-sap-planner-cli.agent.md
@@ -354,15 +354,15 @@ The agent (you) and the Praman fixture (`ui5`) operate in **different phases**:
 You explore the live SAP app using CLI commands. Praman fixtures (`ui5`, `sapAuth`) do NOT exist
 in agent context. Use raw SAP APIs via `run-code`:
 
-| Task             | CLI Command                    | SAP API                                               |
-| ---------------- | ------------------------------ | ----------------------------------------------------- |
+| Task             | CLI Command                    | SAP API                             |
+| ---------------- | ------------------------------ | ----------------------------------- |
 | Find controls    | `run-code "async page => ..."` | `sap.ui.require('sap/ui/core/ElementRegistry').get()` |
-| Read properties  | `run-code "async page => ..."` | `ctrl.getProperty('name')`                            |
-| Check visibility | `run-code "async page => ..."` | `ctrl.getVisible()`                                   |
-| Navigate         | `click e7` (snapshot ref)      | Click tiles/buttons                                   |
-| Take snapshot    | `snapshot --filename=snap.yml` | Visual verification                                   |
-| Fill form        | `fill e3 "value"`              | Fill input fields                                     |
-| Save auth        | `state-save sap-auth.json`     | Persist cookies + storage                             |
+| Read properties  | `run-code "async page => ..."` | `ctrl.getProperty('name')`          |
+| Check visibility | `run-code "async page => ..."` | `ctrl.getVisible()`                 |
+| Navigate         | `click e7` (snapshot ref)      | Click tiles/buttons                 |
+| Take snapshot    | `snapshot --filename=snap.yml` | Visual verification                 |
+| Fill form        | `fill e3 "value"`              | Fill input fields                   |
+| Save auth        | `state-save sap-auth.json`     | Persist cookies + storage           |
 
 ### Test Phase (Generated .spec.ts -- LATER)
 

--- a/skills/praman-sap-cli/SKILL.md
+++ b/skills/praman-sap-cli/SKILL.md
@@ -6,7 +6,6 @@ description: >
   Extends playwright-cli with SAP/UI5 awareness.
 allowed-tools: Bash(playwright-cli:*) Bash(npx:*) Bash(npm:*)
 ---
-
 # SAP UI5 Test Automation via Playwright CLI
 
 **Package**: `playwright-praman` v1.1.2
@@ -40,10 +39,10 @@ PRAMAN_EOF
 
 ## eval vs run-code
 
-| Use         | Command    | Syntax                                                      |
-| ----------- | ---------- | ----------------------------------------------------------- |
-| Quick check | `eval`     | `playwright-cli eval "() => window.__praman_bridge?.ready"` |
-| Multi-step  | `run-code` | `playwright-cli run-code "async page => { ... }"`           |
+| Use | Command | Syntax |
+|-----|---------|--------|
+| Quick check | `eval` | `playwright-cli eval "() => window.__praman_bridge?.ready"` |
+| Multi-step | `run-code` | `playwright-cli run-code "async page => { ... }"` |
 
 **CRITICAL:** `eval` requires a function wrapper `() => expr`. Bare expressions will fail.
 
@@ -56,7 +55,6 @@ playwright-cli eval "window.__praman_bridge?.ready"
 ```
 
 **`run-code` rules:**
-
 - Only `page` is in scope — no `process.env`, no `require()`
 - `console.log()` is invisible — always use `return` to get data
 - Return ONLY serializable values: strings, numbers, booleans, null, plain objects, arrays
@@ -120,12 +118,12 @@ playwright-cli -s=sap run-code "async page => {
 
 Shipped in `node_modules/playwright-praman/dist/scripts/`:
 
-| Script               | Purpose                             | Parameterized |
-| -------------------- | ----------------------------------- | :-----------: |
-| `discover-all.js`    | All controls with methods (max 100) |      No       |
-| `wait-for-ui5.js`    | Poll for UI5 stability              |      No       |
-| `bridge-status.js`   | Bridge readiness diagnostics        |      No       |
-| `dialog-controls.js` | Controls inside open dialogs        |      No       |
+| Script | Purpose | Parameterized |
+|--------|---------|:---:|
+| `discover-all.js` | All controls with methods (max 100) | No |
+| `wait-for-ui5.js` | Poll for UI5 stability | No |
+| `bridge-status.js` | Bridge readiness diagnostics | No |
+| `dialog-controls.js` | Controls inside open dialogs | No |
 
 Usage: `playwright-cli -s=sap run-code "$(cat node_modules/playwright-praman/dist/scripts/SCRIPT.js)"`
 
@@ -470,12 +468,12 @@ dialogs, ensuring the control is found even when it is outside the normal DOM tr
 Different FLP layouts require different navigation methods. Choose the correct one
 based on the target element type:
 
-| Method                           | Target Element        | Use When                          |
-| -------------------------------- | --------------------- | --------------------------------- |
-| `navigateToSpace('Space Name')`  | `sap.m.IconTabFilter` | FLP Space Tab navigation          |
-| `navigateToSectionLink('App')`   | Section link (role)   | Section link within a Space       |
-| `navigateToTile('Tile Header')`  | `sap.m.GenericTile`   | GenericTile layout (classic FLP)  |
-| `navigateToApp('SemObj-action')` | Hash-based intent     | Direct semantic object navigation |
+| Method                             | Target Element          | Use When                                 |
+| ---------------------------------- | ----------------------- | ---------------------------------------- |
+| `navigateToSpace('Space Name')`    | `sap.m.IconTabFilter`  | FLP Space Tab navigation                 |
+| `navigateToSectionLink('App')`     | Section link (role)     | Section link within a Space              |
+| `navigateToTile('Tile Header')`    | `sap.m.GenericTile`    | GenericTile layout (classic FLP)         |
+| `navigateToApp('SemObj-action')`   | Hash-based intent      | Direct semantic object navigation        |
 
 ### Space Tab navigation
 
@@ -592,12 +590,12 @@ playwright-cli snapshot --filename=after-save.yml
 
 ## Troubleshooting
 
-| Symptom                       | Cause                                  | Fix                                                                    |
-| ----------------------------- | -------------------------------------- | ---------------------------------------------------------------------- |
-| `bridge not ready`            | Missing `--config` flag                | Add `--config=.playwright/praman-cli.config.json` to `open` command    |
-| `eval` returns nothing        | Bare expression (no wrapper)           | Wrap in `() => expr`: `playwright-cli eval "() => expr"`               |
-| `console.log` invisible       | `run-code` captures return, not stdout | Use `return` instead of `console.log`                                  |
-| `snapshot` filename error     | Missing `--filename`                   | Use `playwright-cli screenshot --filename=step-01.png`                 |
-| 0 controls found              | Page not fully loaded                  | Run `wait-for-ui5.js` script first                                     |
-| `$(cat ...)` fails on Windows | Bash-only syntax                       | Use PowerShell: `playwright-cli run-code (Get-Content script.js -Raw)` |
-| Token overflow                | Too many controls                      | Discovery scripts cap at 100; use type filter for targeted queries     |
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `bridge not ready` | Missing `--config` flag | Add `--config=.playwright/praman-cli.config.json` to `open` command |
+| `eval` returns nothing | Bare expression (no wrapper) | Wrap in `() => expr`: `playwright-cli eval "() => expr"` |
+| `console.log` invisible | `run-code` captures return, not stdout | Use `return` instead of `console.log` |
+| `snapshot` filename error | Missing `--filename` | Use `playwright-cli screenshot --filename=step-01.png` |
+| 0 controls found | Page not fully loaded | Run `wait-for-ui5.js` script first |
+| `$(cat ...)` fails on Windows | Bash-only syntax | Use PowerShell: `playwright-cli run-code (Get-Content script.js -Raw)` |
+| Token overflow | Too many controls | Discovery scripts cap at 100; use type filter for targeted queries |

--- a/skills/praman-sap-cli/references/eval-patterns.md
+++ b/skills/praman-sap-cli/references/eval-patterns.md
@@ -72,11 +72,11 @@ playwright-cli -s=sap eval "() => { const c = sap.ui.getCore().byId('myInput'); 
 
 ## When to Use eval vs run-code
 
-| Scenario                      | Use                              |
-| ----------------------------- | -------------------------------- |
-| Single expression check       | `eval`                           |
-| Read one property             | `eval`                           |
-| Multi-step operation          | `run-code`                       |
-| Page.evaluate with parameters | `run-code`                       |
-| Async operations              | `run-code`                       |
-| Complex control discovery     | `run-code` (or pre-built script) |
+| Scenario | Use |
+|----------|-----|
+| Single expression check | `eval` |
+| Read one property | `eval` |
+| Multi-step operation | `run-code` |
+| Page.evaluate with parameters | `run-code` |
+| Async operations | `run-code` |
+| Complex control discovery | `run-code` (or pre-built script) |

--- a/skills/praman-sap-cli/references/run-code-patterns.md
+++ b/skills/praman-sap-cli/references/run-code-patterns.md
@@ -257,12 +257,12 @@ playwright-cli -s=sap run-code "async page => {
 
 ## 8. Pre-Built Scripts Reference
 
-| Script          | File                              | Purpose                             |
-| --------------- | --------------------------------- | ----------------------------------- |
-| Discover All    | `dist/scripts/discover-all.js`    | All controls with methods (max 100) |
-| Wait for UI5    | `dist/scripts/wait-for-ui5.js`    | Poll for UI5 stability              |
-| Bridge Status   | `dist/scripts/bridge-status.js`   | Quick diagnostics                   |
-| Dialog Controls | `dist/scripts/dialog-controls.js` | Controls inside open dialogs        |
+| Script | File | Purpose |
+|--------|------|---------|
+| Discover All | `dist/scripts/discover-all.js` | All controls with methods (max 100) |
+| Wait for UI5 | `dist/scripts/wait-for-ui5.js` | Poll for UI5 stability |
+| Bridge Status | `dist/scripts/bridge-status.js` | Quick diagnostics |
+| Dialog Controls | `dist/scripts/dialog-controls.js` | Controls inside open dialogs |
 
 Usage pattern:
 
@@ -277,13 +277,11 @@ playwright-cli -s=sap run-code "$(cat node_modules/playwright-praman/dist/script
 `run-code` returns ONLY the value from the last `return` statement.
 
 **Allowed return types:**
-
 - Strings, numbers, booleans, null
 - Plain objects (no class instances)
 - Arrays of the above
 
 **NOT allowed (will fail silently or throw):**
-
 - Functions
 - DOM nodes / elements
 - Symbols


### PR DESCRIPTION
Found by running `npm run ci` on `main` after #226 merged. Two problems, one of which hid the other.

## The validator was never running in CI

`validate:agent-assets` was added to the `ci` **npm script** in #226 — but **no workflow invokes `npm run ci`**. The quality job runs `lint`, `typecheck`, `cspell`, `knip` and `markdownlint` as individual steps. So the check existed and passed locally while never executing in GitHub, and #226 went green with the assets already drifting.

Added it to the quality job explicitly.

## The drift it was hiding

`lint-staged` runs `prettier --write` over `*.{json,md,yml,yaml}`. On commit it reformatted the **generated** markdown (table column padding) while the `.claude/` sources were not staged and kept their original formatting:

```
< | Read properties  | `run-code "async page => ..."` | `ctrl.getProperty('name')`          |
> | Read properties  | `run-code "async page => ..."` | `ctrl.getProperty('name')`               |
```

Six files had drifted this way. These trees are *copies*, not hand-edited files, so any reformatting is permanent false drift — and would have desensitised the check. Added `agents/`, `seeds/` and `skills/praman-sap-cli/` to `.prettierignore` and regenerated.

## Verification

- `npm run ci` green; generated files byte-identical to their sources again
- Re-committing does **not** reintroduce the reformatting — `.prettierignore` holds
- Re-verified against a simulated clean checkout (`git archive`): passes with 33 content-verified and 4 presence-only, the CI case where the git-ignored `.claude/` sources are absent