### PR TITLE
chore: ignore artifacts of running init inside this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,14 @@ tests/type-compat/package-lock.json
 !seeds/**
 !skills/praman-sap-cli/
 !skills/praman-sap-cli/**
+
+# Artifacts of running `playwright-praman init` inside this repo itself.
+# Each duplicates a tracked source, so committing them would create a second
+# copy that silently drifts:
+#   praman-prompts/     <- scaffolded copy of tracked prompts/
+#   examples/telemetry/ <- scaffolded copy of tracked examples/*.ts
+# Root-anchored so consumer projects are unaffected.
+/praman-prompts/
+/examples/telemetry/
+/bom-e2e-praman-gold-standard.spec.ts
+/playwright.config.original.ts


### PR DESCRIPTION
Housekeeping ahead of new feature work — the working tree had 10 untracked files sitting in it.

Running `playwright-praman init` inside this repo scaffolds *into the repo itself*, leaving behind:

| Untracked | Duplicates |
|---|---|
| `praman-prompts/` (5 files) | tracked `prompts/` |
| `examples/telemetry/` (3 files) | tracked `examples/*.ts` |
| `bom-e2e-praman-gold-standard.spec.ts` | tracked `examples/` copy |
| `playwright.config.original.ts` | a stray config backup |

I diffed every one: all byte-identical to their tracked source (the config backup aside). Committing them would create a second copy that silently drifts out of sync — the same failure mode as the generated agent trees in #228, where prettier reformatted one copy and not the other.

Ignored rather than committed, root-anchored (`/praman-prompts/`) so consumer projects are unaffected.

Working tree is clean after this.