### PR TITLE
feat(fixtures): handle SAP overlays that interrupt an action

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -3,8 +3,8 @@
   "name": "playwright-praman",
   "description": "Capability manifest for Praman SAP UI5 test automation",
   "registryVersion": 1,
-  "generatedAt": "2026-05-25",
-  "totalCapabilities": 183,
+  "generatedAt": "2026-08-26",
+  "totalCapabilities": 187,
   "categories": {
     "ui5": {
       "prefix": "UI5",
@@ -2474,6 +2474,48 @@
       "usageExample": "import { getControlAggregation } from 'playwright-praman';\nconst items = await getControlAggregation(page, '__list0', 'items');",
       "registryVersion": 1,
       "aiSteering": "Use ui5.table methods or expect(table).toHaveUI5RowCount(n) matcher for table assertions instead."
+    },
+    {
+      "id": "UI5-DLG-090",
+      "qualifiedName": "ui5Overlays.register",
+      "name": "register",
+      "description": "Registers a rule for an SAP overlay that can interrupt an action. Detects and reports by default; pass a dismiss function to opt into auto-dismissal.",
+      "category": "dialog",
+      "priority": "fixture",
+      "usageExample": "await overlays.register({\n  name: 'cookie-consent',\n  selector: '#cookieBanner',\n  dismiss: async (overlay) => overlay.getByRole('button', { name: 'Accept' }).click(),\n});",
+      "registryVersion": 1,
+      "aiSteering": "Prefer detect-only rules. Only supply a dismiss function when answering the overlay cannot change what the test asserts."
+    },
+    {
+      "id": "UI5-DLG-091",
+      "qualifiedName": "ui5Overlays.registerAll",
+      "name": "registerAll",
+      "description": "Registers several overlay rules in one call.",
+      "category": "dialog",
+      "priority": "fixture",
+      "usageExample": "await overlays.registerAll(BUILT_IN_OVERLAY_RULES);",
+      "registryVersion": 1
+    },
+    {
+      "id": "UI5-DLG-092",
+      "qualifiedName": "ui5Overlays.dispose",
+      "name": "dispose",
+      "description": "Unregisters every overlay rule this handler registered. Called automatically by the overlays fixture on teardown.",
+      "category": "dialog",
+      "priority": "fixture",
+      "usageExample": "await overlays.dispose();",
+      "registryVersion": 1
+    },
+    {
+      "id": "UI5-OTHER-001",
+      "qualifiedName": "fixtures.attachBridgeNavigationReset",
+      "name": "attachBridgeNavigationReset",
+      "description": "Attaches a framenavigated listener that resets bridge injection state on main-frame navigation. Returns a cleanup function that removes the listener.",
+      "category": "assert",
+      "priority": "implementation",
+      "usageExample": "const detach = attachBridgeNavigationReset(page, logger);\nawait use(handler);\ndetach();",
+      "registryVersion": 1,
+      "aiSteering": "Use this helper inside fixture setUp to ensure the bridge is re-injected after every full-page navigation."
     }
   ]
 }

--- a/capabilities.yaml
+++ b/capabilities.yaml
@@ -2576,6 +2576,45 @@ capabilities:
       const items = await getControlAggregation(page, '__list0', 'items');
     registryVersion: 1
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # Namespace: ui5Overlays — SAP overlays that interrupt an action
+  # ════════════════════════════════════════════════════════════════════════════
+
+  - id: UI5-DLG-090
+    qualifiedName: ui5Overlays.register
+    name: register
+    description: 'Registers a rule for an SAP overlay that can interrupt an action. Detects and reports by default; pass a dismiss function to opt into auto-dismissal.'
+    category: dialog
+    priority: fixture
+    aiSteering: 'Prefer detect-only rules. Only supply a dismiss function when answering the overlay cannot change what the test asserts.'
+    usageExample: |
+      await overlays.register({
+        name: 'cookie-consent',
+        selector: '#cookieBanner',
+        dismiss: async (overlay) => overlay.getByRole('button', { name: 'Accept' }).click(),
+      });
+    registryVersion: 1
+
+  - id: UI5-DLG-091
+    qualifiedName: ui5Overlays.registerAll
+    name: registerAll
+    description: 'Registers several overlay rules in one call.'
+    category: dialog
+    priority: fixture
+    usageExample: |
+      await overlays.registerAll(BUILT_IN_OVERLAY_RULES);
+    registryVersion: 1
+
+  - id: UI5-DLG-092
+    qualifiedName: ui5Overlays.dispose
+    name: dispose
+    description: 'Unregisters every overlay rule this handler registered. Called automatically by the overlays fixture on teardown.'
+    category: dialog
+    priority: fixture
+    usageExample: |
+      await overlays.dispose();
+    registryVersion: 1
+
   - id: UI5-OTHER-001
     qualifiedName: fixtures.attachBridgeNavigationReset
     name: attachBridgeNavigationReset

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,7 +1,7 @@
 # Praman Capabilities Reference
 
-> **Generated**: 2026-05-25 — do not edit manually, run `npm run generate:capabilities`
-> **Total**: 183 capabilities across 15 categories
+> **Generated**: 2026-08-26 — do not edit manually, run `npm run generate:capabilities`
+> **Total**: 187 capabilities across 15 categories
 
 ---
 
@@ -11,7 +11,7 @@
 | -------- | ------------ | ---------------------------------------------- | ----- |
 | ui5      | `UI5-UI5`    | Core UI5 control interactions                  | 23    |
 | table    | `UI5-TABLE`  | Table discovery, reading, and manipulation     | 24    |
-| dialog   | `UI5-DLG`    | Dialog lifecycle management                    | 7     |
+| dialog   | `UI5-DLG`    | Dialog lifecycle management                    | 10    |
 | date     | `UI5-DATE`   | Date and time picker operations                | 7     |
 | odata    | `UI5-ODATA`  | OData model and HTTP operations                | 11    |
 | navigate | `UI5-NAV`    | FLP and in-app navigation                      | 9     |
@@ -22,7 +22,7 @@
 | footer   | `UI5-FOOTER` | Footer toolbar actions                         | 6     |
 | flp      | `UI5-FLP`    | Fiori Launchpad services (locks, settings)     | 10    |
 | ai       | `UI5-AI`     | AI-powered discovery and context building      | 9     |
-| assert   | `UI5-ASSERT` | UI5-aware custom matchers for assertions       | 9     |
+| assert   | `UI5-ASSERT` | UI5-aware custom matchers for assertions       | 10    |
 | data     | `UI5-DATA`   | Test data generation, persistence, and cleanup | 4     |
 
 ---
@@ -86,15 +86,18 @@
 
 ## dialog — Dialog lifecycle management
 
-| ID            | Name          | Description                                            | Usage Example                                                            |
-| ------------- | ------------- | ------------------------------------------------------ | ------------------------------------------------------------------------ |
-| `UI5-DLG-001` | waitFor       | Waits for a dialog to appear and returns its metadata. | `const dlg = await ui5.dialog.waitFor({ title: 'Confirm' });`            |
-| `UI5-DLG-002` | getOpen       | Returns all currently open dialogs.                    | `const dialogs = await ui5.dialog.getOpen();`                            |
-| `UI5-DLG-003` | isOpen        | Checks whether a specific dialog is currently open.    | `const open = await ui5.dialog.isOpen('confirmDialog');`                 |
-| `UI5-DLG-004` | dismiss       | Dismisses (closes) a dialog.                           | `await ui5.dialog.dismiss({ title: 'Warning' });`                        |
-| `UI5-DLG-005` | confirm       | Confirms a dialog by clicking its confirmation button. | `await ui5.dialog.confirm({ title: 'Save Changes', buttonText: 'OK' });` |
-| `UI5-DLG-006` | waitForClosed | Waits for a specific dialog to close.                  | `await ui5.dialog.waitForClosed('confirmDialog', { timeout: 5000 });`    |
-| `UI5-DLG-007` | getButtons    | Returns the buttons available in a specific dialog.    | `const buttons = await ui5.dialog.getButtons('confirmDialog');`          |
+| ID            | Name          | Description                                                                                                                                           | Usage Example                                                            |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `UI5-DLG-001` | waitFor       | Waits for a dialog to appear and returns its metadata.                                                                                                | `const dlg = await ui5.dialog.waitFor({ title: 'Confirm' });`            |
+| `UI5-DLG-002` | getOpen       | Returns all currently open dialogs.                                                                                                                   | `const dialogs = await ui5.dialog.getOpen();`                            |
+| `UI5-DLG-003` | isOpen        | Checks whether a specific dialog is currently open.                                                                                                   | `const open = await ui5.dialog.isOpen('confirmDialog');`                 |
+| `UI5-DLG-004` | dismiss       | Dismisses (closes) a dialog.                                                                                                                          | `await ui5.dialog.dismiss({ title: 'Warning' });`                        |
+| `UI5-DLG-005` | confirm       | Confirms a dialog by clicking its confirmation button.                                                                                                | `await ui5.dialog.confirm({ title: 'Save Changes', buttonText: 'OK' });` |
+| `UI5-DLG-006` | waitForClosed | Waits for a specific dialog to close.                                                                                                                 | `await ui5.dialog.waitForClosed('confirmDialog', { timeout: 5000 });`    |
+| `UI5-DLG-007` | getButtons    | Returns the buttons available in a specific dialog.                                                                                                   | `const buttons = await ui5.dialog.getButtons('confirmDialog');`          |
+| `UI5-DLG-090` | register      | Registers a rule for an SAP overlay that can interrupt an action. Detects and reports by default; pass a dismiss function to opt into auto-dismissal. | `await overlays.register({`                                              |
+| `UI5-DLG-091` | registerAll   | Registers several overlay rules in one call.                                                                                                          | `await overlays.registerAll(BUILT_IN_OVERLAY_RULES);`                    |
+| `UI5-DLG-092` | dispose       | Unregisters every overlay rule this handler registered. Called automatically by the overlays fixture on teardown.                                     | `await overlays.dispose();`                                              |
 
 ## date — Date and time picker operations
 
@@ -264,17 +267,18 @@
 
 ## assert — UI5-aware custom matchers for assertions
 
-| ID               | Name                  | Description                                                                                                                | Usage Example                                                |
-| ---------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `UI5-ASSERT-001` | toHaveUI5Text         | Assert control has expected text.                                                                                          | `await expect(locator).toHaveUI5Text('Expected text');`      |
-| `UI5-ASSERT-002` | toBeUI5Visible        | Assert UI5 control is visible.                                                                                             | `await expect(locator).toBeUI5Visible();`                    |
-| `UI5-ASSERT-003` | toBeUI5Enabled        | Assert UI5 control is enabled.                                                                                             | `await expect(locator).toBeUI5Enabled();`                    |
-| `UI5-ASSERT-004` | toHaveUI5Property     | Assert control has specific property value.                                                                                | `await expect(locator).toHaveUI5Property('enabled', true);`  |
-| `UI5-ASSERT-005` | toHaveUI5ValueState   | Assert control value state (Error, Warning, etc.).                                                                         | `await expect(locator).toHaveUI5ValueState('Success');`      |
-| `UI5-ASSERT-006` | toHaveUI5RowCount     | Assert table has expected row count.                                                                                       | `await expect(table).toHaveUI5RowCount(5);`                  |
-| `UI5-ASSERT-007` | toHaveUI5CellText     | Assert table cell contains expected text.                                                                                  | `await expect(table).toHaveUI5CellText(0, 2, 'MAT-001');`    |
-| `UI5-ASSERT-008` | getControlProperty    | Low-level bridge call to read a single property from a UI5 control by ID. Used internally by matchers.                     | `import { getControlProperty } from 'playwright-praman';`    |
-| `UI5-ASSERT-009` | getControlAggregation | Low-level bridge call to read an aggregation (child controls) from a UI5 control by ID. Used internally by table matchers. | `import { getControlAggregation } from 'playwright-praman';` |
+| ID               | Name                        | Description                                                                                                                                           | Usage Example                                                |
+| ---------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `UI5-ASSERT-001` | toHaveUI5Text               | Assert control has expected text.                                                                                                                     | `await expect(locator).toHaveUI5Text('Expected text');`      |
+| `UI5-ASSERT-002` | toBeUI5Visible              | Assert UI5 control is visible.                                                                                                                        | `await expect(locator).toBeUI5Visible();`                    |
+| `UI5-ASSERT-003` | toBeUI5Enabled              | Assert UI5 control is enabled.                                                                                                                        | `await expect(locator).toBeUI5Enabled();`                    |
+| `UI5-ASSERT-004` | toHaveUI5Property           | Assert control has specific property value.                                                                                                           | `await expect(locator).toHaveUI5Property('enabled', true);`  |
+| `UI5-ASSERT-005` | toHaveUI5ValueState         | Assert control value state (Error, Warning, etc.).                                                                                                    | `await expect(locator).toHaveUI5ValueState('Success');`      |
+| `UI5-ASSERT-006` | toHaveUI5RowCount           | Assert table has expected row count.                                                                                                                  | `await expect(table).toHaveUI5RowCount(5);`                  |
+| `UI5-ASSERT-007` | toHaveUI5CellText           | Assert table cell contains expected text.                                                                                                             | `await expect(table).toHaveUI5CellText(0, 2, 'MAT-001');`    |
+| `UI5-ASSERT-008` | getControlProperty          | Low-level bridge call to read a single property from a UI5 control by ID. Used internally by matchers.                                                | `import { getControlProperty } from 'playwright-praman';`    |
+| `UI5-ASSERT-009` | getControlAggregation       | Low-level bridge call to read an aggregation (child controls) from a UI5 control by ID. Used internally by table matchers.                            | `import { getControlAggregation } from 'playwright-praman';` |
+| `UI5-OTHER-001`  | attachBridgeNavigationReset | Attaches a framenavigated listener that resets bridge injection state on main-frame navigation. Returns a cleanup function that removes the listener. | `const detach = attachBridgeNavigationReset(page, logger);`  |
 
 ## data — Test data generation, persistence, and cleanup
 

--- a/skills/playwright-praman-sap-testing/capabilities-reference.md
+++ b/skills/playwright-praman-sap-testing/capabilities-reference.md
@@ -1,7 +1,7 @@
 # Praman Capabilities Reference (Agent)
 
-> Generated: 2026-05-25 — do not edit manually, run `npm run generate:capabilities`
-> Total: 183 capabilities
+> Generated: 2026-08-26 — do not edit manually, run `npm run generate:capabilities`
+> Total: 187 capabilities
 
 ---
 
@@ -67,6 +67,9 @@
 - **ui5.dialog.confirm** — Confirms a dialog by clicking its confirmation button.
 - **ui5.dialog.waitForClosed** — Waits for a specific dialog to close.
 - **ui5.dialog.getButtons** — Returns the buttons available in a specific dialog.
+- **ui5Overlays.register** — Registers a rule for an SAP overlay that can interrupt an action. Detects and reports by default; pass a dismiss function to opt into auto-dismissal.
+- **ui5Overlays.registerAll** — Registers several overlay rules in one call.
+- **ui5Overlays.dispose** — Unregisters every overlay rule this handler registered. Called automatically by the overlays fixture on teardown.
 
 ## date — Date and time picker operations
 
@@ -225,6 +228,7 @@
 - **matchers.toHaveUI5CellText** — Assert table cell contains expected text.
 - **matchers.getControlProperty** — Low-level bridge call to read a single property from a UI5 control by ID. Used internally by matchers.
 - **matchers.getControlAggregation** — Low-level bridge call to read an aggregation (child controls) from a UI5 control by ID. Used internally by table matchers.
+- **fixtures.attachBridgeNavigationReset** — Attaches a framenavigated listener that resets bridge injection state on main-frame navigation. Returns a cleanup function that removes the listener.
 
 ## data — Test data generation, persistence, and cleanup
 

--- a/src/ai/capability-registry.generated.ts
+++ b/src/ai/capability-registry.generated.ts
@@ -24,7 +24,7 @@ import type { CapabilityEntry } from './schemas/capability.schema.js';
  * Static list of generated capability entries.
  *
  * @remarks
- * Generated on 2026-05-25 with 183 entries.
+ * Generated on 2026-08-26 with 187 entries.
  */
 export const GENERATED_CAPABILITIES: readonly CapabilityEntry[] = [
   {
@@ -2338,5 +2338,54 @@ export const GENERATED_CAPABILITIES: readonly CapabilityEntry[] = [
     registryVersion: 1,
     aiSteering:
       'Use ui5.table methods or expect(table).toHaveUI5RowCount(n) matcher for table assertions instead.',
+  },
+  {
+    id: 'UI5-DLG-090',
+    qualifiedName: 'ui5Overlays.register',
+    name: 'register',
+    description:
+      'Registers a rule for an SAP overlay that can interrupt an action. Detects and reports by default; pass a dismiss function to opt into auto-dismissal.',
+    category: 'dialog',
+    priority: 'fixture',
+    usageExample:
+      "await overlays.register({\n  name: 'cookie-consent',\n  selector: '#cookieBanner',\n  dismiss: async (overlay) => overlay.getByRole('button', { name: 'Accept' }).click(),\n});",
+    registryVersion: 1,
+    aiSteering:
+      'Prefer detect-only rules. Only supply a dismiss function when answering the overlay cannot change what the test asserts.',
+  },
+  {
+    id: 'UI5-DLG-091',
+    qualifiedName: 'ui5Overlays.registerAll',
+    name: 'registerAll',
+    description: 'Registers several overlay rules in one call.',
+    category: 'dialog',
+    priority: 'fixture',
+    usageExample: 'await overlays.registerAll(BUILT_IN_OVERLAY_RULES);',
+    registryVersion: 1,
+  },
+  {
+    id: 'UI5-DLG-092',
+    qualifiedName: 'ui5Overlays.dispose',
+    name: 'dispose',
+    description:
+      'Unregisters every overlay rule this handler registered. Called automatically by the overlays fixture on teardown.',
+    category: 'dialog',
+    priority: 'fixture',
+    usageExample: 'await overlays.dispose();',
+    registryVersion: 1,
+  },
+  {
+    id: 'UI5-OTHER-001',
+    qualifiedName: 'fixtures.attachBridgeNavigationReset',
+    name: 'attachBridgeNavigationReset',
+    description:
+      'Attaches a framenavigated listener that resets bridge injection state on main-frame navigation. Returns a cleanup function that removes the listener.',
+    category: 'assert',
+    priority: 'implementation',
+    usageExample:
+      'const detach = attachBridgeNavigationReset(page, logger);\nawait use(handler);\ndetach();',
+    registryVersion: 1,
+    aiSteering:
+      'Use this helper inside fixture setUp to ensure the bridge is re-injected after every full-page navigation.',
   },
 ] as const;

--- a/src/core/config/schema.ts
+++ b/src/core/config/schema.ts
@@ -175,6 +175,18 @@ const controlTreeCaptureSchema = z.object({
   maxControls: z.number().int().positive().default(5_000),
 });
 
+// ── Overlay interruption sub-schema ──────────────────────────────────
+const overlaysSchema = z.object({
+  /**
+   * Whether to register the built-in overlay rules.
+   *
+   * @remarks
+   * The built-ins are detect-only — they never dismiss anything. Disable this
+   * to register nothing automatically and drive `overlays.register()` yourself.
+   */
+  enabled: z.boolean().default(true),
+});
+
 // ── OPA5 sub-schema (D7) ────────────────────────────────────────────
 const opa5Schema = z.object({
   interactionTimeout: z.number().int().positive().default(5_000),
@@ -217,6 +229,7 @@ export const PramanConfigSchema = z
     opa5: opa5Schema.optional(),
     odataTracing: odataTracingSchema.optional(),
     controlTreeCapture: controlTreeCaptureSchema.optional(),
+    overlays: overlaysSchema.optional(),
     /** Default value for matchSubclasses on selectors that don't specify it. */
     defaultMatchSubclasses: z.boolean().default(false),
     /**

--- a/src/fixtures/index.ts
+++ b/src/fixtures/index.ts
@@ -45,6 +45,7 @@ import { intentTest } from './intent-fixtures.js';
 import { moduleTest } from './module-fixtures.js';
 import { navTest } from './nav-fixtures.js';
 import { odataTraceTest } from './odata-trace-fixtures.js';
+import { overlayTest } from './overlay-fixtures.js';
 import { screencastTest } from './screencast-fixture.js';
 import { shellFooterTest } from './shell-footer-fixtures.js';
 import { stabilityTest } from './stability-fixtures.js';
@@ -100,6 +101,7 @@ export const test = mergeTests(
   stabilityTest,
   controlTreeTest,
   failureArtifactsTest,
+  overlayTest,
   feTest,
   aiTest,
   intentTest,
@@ -483,3 +485,29 @@ export type { WebStorageFixture, WebStorageHelper } from './web-storage-fixture.
  */
 export { failureArtifactsTest } from './failure-artifacts-fixture.js';
 export type { FailureArtifactsFixtures } from './failure-artifacts-fixture.js';
+
+/**
+ * Overlay interruption handling for SAP overlays that block an action.
+ *
+ * @remarks
+ * Built-in rules detect and report without dismissing anything. Supply a
+ * `dismiss` function to opt into auto-dismissal for a specific overlay.
+ *
+ * @example
+ * ```typescript
+ * import { overlayTest } from 'playwright-praman';
+ *
+ * overlayTest('survives the cookie banner', async ({ page, overlays }) => {
+ *   await overlays.register({
+ *     name: 'cookie-consent',
+ *     selector: '#cookieBanner',
+ *     dismiss: async (overlay) => overlay.getByRole('button', { name: 'Accept' }).click(),
+ *   });
+ *   await page.goto('/');
+ * });
+ * ```
+ */
+export { overlayTest } from './overlay-fixtures.js';
+export type { OverlayFixtures } from './overlay-fixtures.js';
+export { BUILT_IN_OVERLAY_RULES, OverlayHandler } from './overlay-handler.js';
+export type { OverlayDetection, OverlayRule } from './overlay-handler.js';

--- a/src/fixtures/overlay-fixtures.ts
+++ b/src/fixtures/overlay-fixtures.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright (c) ZesTest 2025-2030. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file may contain AI-assisted code.
+ * See LICENSE and NOTICE files for details.
+ */
+
+/**
+ * Overlay fixtures — Playwright fixture wrapping {@link OverlayHandler}.
+ *
+ * @ai
+ * @aiContext Provides the `overlays` fixture for handling SAP overlays that
+ * interrupt an action. Built-in rules detect and report; call
+ * `overlays.register()` with a `dismiss` function to opt into auto-dismissal.
+ *
+ * @remarks
+ * The fixture registers {@link BUILT_IN_OVERLAY_RULES} at test start, unless
+ * disabled via `overlays.enabled: false` in `praman.config.ts`. Rules are torn
+ * down at the end of the test, because `page.addLocatorHandler()` registrations
+ * otherwise live for the whole page lifetime.
+ *
+ * When any overlay interrupted an action, the detections are attached to the
+ * test report as `overlay-detections` — so a "click timed out" becomes a named
+ * diagnosis instead of a mystery.
+ *
+ * @example
+ * ```typescript
+ * import { overlayTest } from '#fixtures/overlay-fixtures.js';
+ *
+ * overlayTest('dismiss the product tour', async ({ page, overlays }) => {
+ *   await overlays.register({
+ *     name: 'product-tour',
+ *     selector: '.myTourPopover',
+ *     dismiss: async (overlay) => overlay.getByRole('button', { name: 'Skip' }).click(),
+ *   });
+ *   await page.goto('/');
+ * });
+ * ```
+ *
+ * @module fixtures
+ */
+
+import { Buffer } from 'node:buffer';
+
+import type { Page } from '@playwright/test';
+import { test as base } from '@playwright/test';
+
+import { BUILT_IN_OVERLAY_RULES, OverlayHandler } from './overlay-handler.js';
+
+import type { PramanConfig } from '#core/config/schema.js';
+import { createLogger } from '#core/logging/logger.js';
+
+// ── Public fixture types ───────────────────────────────────────────────────
+
+/**
+ * Fixture types for overlay interruption handling.
+ *
+ * @example
+ * ```typescript
+ * import type { OverlayFixtures } from '#fixtures/overlay-fixtures.js';
+ * ```
+ */
+export interface OverlayFixtures {
+  /** Registers and tracks SAP overlay interruption handlers. */
+  overlays: OverlayHandler;
+}
+
+/**
+ * Worker-scoped dependencies supplied by `coreTest` through `mergeTests`.
+ *
+ * @example
+ * ```typescript
+ * import type { OverlayDeps } from '#fixtures/overlay-fixtures.js';
+ * ```
+ */
+export interface OverlayDeps {
+  pramanConfig: Readonly<PramanConfig>;
+}
+
+// ── Fixture definition ─────────────────────────────────────────────────────
+
+/**
+ * Playwright test object extended with the `overlays` fixture.
+ *
+ * @remarks
+ * Built-in rules are registered before the test body runs and removed after it,
+ * and any detections are attached to the report.
+ *
+ * @capability ui5Overlays.register
+ *
+ * @example
+ * ```typescript
+ * overlayTest('checkout survives interruptions', async ({ page, overlays }) => {
+ *   await page.goto('/');
+ *   // overlays.detections lists anything that interrupted an action
+ * });
+ * ```
+ */
+export const overlayTest = base.extend<OverlayFixtures, OverlayDeps>({
+  // Placeholder — provided by coreTest via mergeTests (PW-MERGE-1)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- PW-MERGE-1: placeholder overridden by mergeTests
+  pramanConfig: [undefined!, { option: true, scope: 'worker' }],
+
+  overlays: async (
+    { page, pramanConfig }: { page: Page; pramanConfig: Readonly<PramanConfig> },
+    use,
+    testInfo,
+  ) => {
+    const log = createLogger('overlay-fixture');
+    const handler = new OverlayHandler({ page });
+
+    // Undefined means standalone usage without loadConfig — default to enabled,
+    // matching the Zod schema default.
+    if (pramanConfig.overlays?.enabled !== false) {
+      try {
+        await handler.registerAll(BUILT_IN_OVERLAY_RULES);
+      } catch (error: unknown) {
+        // Registration is a convenience; never fail a test because of it.
+        log.debug({ err: error }, 'Built-in overlay rule registration failed (non-fatal)');
+      }
+    }
+
+    await use(handler);
+
+    if (handler.detections.length > 0) {
+      try {
+        await testInfo.attach('overlay-detections', {
+          contentType: 'application/json',
+          body: Buffer.from(JSON.stringify(handler.detections, null, 2), 'utf8'),
+        });
+      } catch (error: unknown) {
+        log.debug({ err: error }, 'Overlay detection attachment failed (non-fatal)');
+      }
+    }
+
+    await handler.dispose();
+  },
+});

--- a/src/fixtures/overlay-handler.ts
+++ b/src/fixtures/overlay-handler.ts
@@ -1,0 +1,338 @@
+/**
+ * @license
+ * Copyright (c) ZesTest 2025-2030. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file may contain AI-assisted code.
+ * See LICENSE and NOTICE files for details.
+ */
+
+/**
+ * Overlay interruption handler — automatic handling of SAP overlays that
+ * interrupt an action.
+ *
+ * @ai
+ * @aiContext Registers Playwright locator handlers for SAP overlays that appear
+ * unpredictably mid-action (unexpected modal dialogs, cookie banners, product
+ * tours). Detects and reports by default; dismisses only when a rule explicitly
+ * supplies a `dismiss` function.
+ *
+ * @remarks
+ * Built on `page.addLocatorHandler()`, available since Playwright 1.42 and
+ * therefore below Praman's 1.57 floor — no version gate is required.
+ *
+ * Three design constraints are deliberate and load-bearing:
+ *
+ * 1. **Detect, don't dismiss.** A handler that silently answers a dialog can
+ *    turn a genuine failure into a passing test. Rules report by default;
+ *    dismissal is opt-in per rule and always logged at `warn`.
+ * 2. **Busy state is not an overlay.** `BusyIndicator` and the UI5 block layer
+ *    are handled by {@link waitForUI5Stable}. Registering a handler for them
+ *    too would put two independent wait mechanisms on every action, with no
+ *    defined precedence when they disagree.
+ * 3. **Plain CSS only, for built-ins.** Playwright evaluates every registered
+ *    locator before every action and assertion. The `ui5=` selector engine
+ *    walks the whole UI5 control tree, so built-in rules use SAP's stable class
+ *    names instead. User-defined rules may use `ui5=` where control semantics
+ *    are genuinely needed.
+ *
+ * @example
+ * ```typescript
+ * import { OverlayHandler } from '#fixtures/overlay-handler.js';
+ *
+ * const overlays = new OverlayHandler({ page });
+ * await overlays.register({
+ *   name: 'cookie-consent',
+ *   selector: '#cookieBanner',
+ *   dismiss: async (overlay) => overlay.getByRole('button', { name: 'Accept' }).click(),
+ * });
+ * ```
+ *
+ * @module fixtures
+ */
+
+import type { Locator, Page } from '@playwright/test';
+import type { Logger } from 'pino';
+
+import { PramanError } from '#core/errors/base.js';
+import { ErrorCode } from '#core/errors/codes.js';
+import { createLogger } from '#core/logging/logger.js';
+
+/** Default cap on how many times a single rule may fire within one test. */
+const DEFAULT_TIMES = 5;
+
+/** Maximum characters of overlay text retained in a detection record. */
+const MAX_TEXT_LENGTH = 200;
+
+/**
+ * A rule describing one overlay that may interrupt an action.
+ *
+ * @remarks
+ * Omit `dismiss` to detect and report only — the recommended default. Supply
+ * `dismiss` only when answering the overlay cannot change the meaning of the
+ * test.
+ *
+ * @example
+ * ```typescript
+ * const rule: OverlayRule = {
+ *   name: 'product-tour',
+ *   selector: '.myTourPopover',
+ *   dismiss: async (overlay) => overlay.getByRole('button', { name: 'Skip' }).click(),
+ * };
+ * ```
+ */
+export interface OverlayRule {
+  /** Stable identifier, used in logs and report attachments. */
+  readonly name: string;
+  /**
+   * Playwright selector locating the overlay. Prefer plain CSS — this is
+   * evaluated before every action.
+   */
+  readonly selector: string;
+  /**
+   * How to dismiss the overlay. When omitted the overlay is recorded and
+   * reported but never touched.
+   */
+  readonly dismiss?: (overlay: Locator) => Promise<void>;
+  /** Maximum times this rule may fire per test. Defaults to 5. */
+  readonly times?: number;
+}
+
+/**
+ * A single occurrence of an overlay interrupting an action.
+ *
+ * @example
+ * ```typescript
+ * const detection: OverlayDetection = handler.detections[0];
+ * logger.info(detection.rule); // 'unexpected-dialog'
+ * ```
+ */
+export interface OverlayDetection {
+  /** Name of the rule that fired. */
+  readonly rule: string;
+  /** Trimmed text content of the overlay, for diagnosis. */
+  readonly text: string;
+  /** Whether a dismiss function ran successfully. */
+  readonly dismissed: boolean;
+  /** Message from a failed dismissal, when one occurred. */
+  readonly error?: string;
+}
+
+/**
+ * Options for constructing an {@link OverlayHandler}.
+ *
+ * @example
+ * ```typescript
+ * const options: OverlayHandlerOptions = { page };
+ * ```
+ */
+export interface OverlayHandlerOptions {
+  readonly page: Page;
+  /** Optional parent logger. A child logger is created when omitted. */
+  readonly logger?: Logger;
+}
+
+/**
+ * Overlay rules registered by default.
+ *
+ * @remarks
+ * Deliberately minimal and strictly non-destructive. The one built-in turns an
+ * opaque "action timed out" into a named diagnosis — "a modal dialog reading
+ * *Session Expiring* blocked this click" — without answering the dialog.
+ *
+ * Which overlays actually appear is highly system-specific (What's New,
+ * cookie consent, custom Z-dialogs), so dismissal rules belong in the
+ * consuming project rather than shipped as guesses.
+ *
+ * @example
+ * ```typescript
+ * import { BUILT_IN_OVERLAY_RULES } from '#fixtures/overlay-handler.js';
+ *
+ * for (const rule of BUILT_IN_OVERLAY_RULES) {
+ *   await overlays.register(rule);
+ * }
+ * ```
+ */
+export const BUILT_IN_OVERLAY_RULES: readonly OverlayRule[] = [
+  {
+    name: 'unexpected-dialog',
+    // `.sapMDialog` is the stable container class for sap.m.Dialog, already
+    // relied on by src/scripts/dialog-controls.ts.
+    selector: '.sapMDialog',
+  },
+];
+
+/**
+ * Registers and tracks SAP overlay interruption handlers for one page.
+ *
+ * @remarks
+ * Handlers registered through `page.addLocatorHandler()` live for the lifetime
+ * of the page, so a handler must be disposed at the end of the test that
+ * registered it. {@link dispose} does that.
+ *
+ * @capability ui5Overlays.register
+ *
+ * @example
+ * ```typescript
+ * const overlays = new OverlayHandler({ page });
+ * await overlays.register({ name: 'tour', selector: '.tourPopover' });
+ * // ... test body ...
+ * await overlays.dispose();
+ * ```
+ */
+export class OverlayHandler {
+  readonly #page: Page;
+  readonly #log: Logger;
+  readonly #registered = new Map<string, Locator>();
+  readonly #detections: OverlayDetection[] = [];
+
+  constructor(options: OverlayHandlerOptions) {
+    this.#page = options.page;
+    this.#log = createLogger('overlay-handler', options.logger);
+  }
+
+  /**
+   * Every overlay interruption recorded so far, in the order they occurred.
+   *
+   * @example
+   * ```typescript
+   * if (overlays.detections.length > 0) {
+   *   logger.warn(`${overlays.detections.length} overlays interrupted this test`);
+   * }
+   * ```
+   */
+  get detections(): readonly OverlayDetection[] {
+    return this.#detections;
+  }
+
+  /**
+   * Registers one overlay rule with Playwright.
+   *
+   * @param rule - The overlay rule to register.
+   * @throws {@link PramanError} with `ERR_CONFIG_INVALID` when the rule name is
+   *   already registered.
+   *
+   * @capability ui5Overlays.register
+   *
+   * @example
+   * ```typescript
+   * await overlays.register({ name: 'cookie-consent', selector: '#cookieBar' });
+   * ```
+   */
+  async register(rule: OverlayRule): Promise<void> {
+    if (this.#registered.has(rule.name)) {
+      throw new PramanError({
+        code: ErrorCode.ERR_CONFIG_INVALID,
+        message: `Overlay rule "${rule.name}" is already registered.`,
+        attempted: `Register overlay rule "${rule.name}"`,
+        retryable: false,
+        details: { rule: rule.name, selector: rule.selector },
+        suggestions: [
+          'Give each overlay rule a unique name',
+          'Call overlays.dispose() before re-registering rules',
+        ],
+      });
+    }
+
+    const locator = this.#page.locator(rule.selector);
+    const isDetectOnly = rule.dismiss === undefined;
+
+    await this.#page.addLocatorHandler(locator, async (overlay) => this.#onOverlay(rule, overlay), {
+      times: rule.times ?? DEFAULT_TIMES,
+      // Nothing dismissed a detect-only overlay, so waiting for it to hide
+      // would stall the action until timeout and bury the diagnosis.
+      noWaitAfter: isDetectOnly,
+    });
+
+    this.#registered.set(rule.name, locator);
+    this.#log.debug(
+      { rule: rule.name, selector: rule.selector, detectOnly: isDetectOnly },
+      'Overlay rule registered',
+    );
+  }
+
+  /**
+   * Registers several overlay rules.
+   *
+   * @param rules - The overlay rules to register.
+   *
+   * @capability ui5Overlays.registerAll
+   *
+   * @example
+   * ```typescript
+   * await overlays.registerAll(BUILT_IN_OVERLAY_RULES);
+   * ```
+   */
+  async registerAll(rules: readonly OverlayRule[]): Promise<void> {
+    for (const rule of rules) {
+      await this.register(rule);
+    }
+  }
+
+  /**
+   * Unregisters every rule this handler registered.
+   *
+   * @remarks
+   * Safe to call on a closed page — removal failures are logged and swallowed,
+   * because teardown must never mask the test's own result.
+   *
+   * @capability ui5Overlays.dispose
+   *
+   * @example
+   * ```typescript
+   * await overlays.dispose();
+   * ```
+   */
+  async dispose(): Promise<void> {
+    for (const [name, locator] of this.#registered) {
+      try {
+        await this.#page.removeLocatorHandler(locator);
+      } catch (error: unknown) {
+        this.#log.debug(
+          { rule: name, error: error instanceof Error ? error.message : String(error) },
+          'Overlay rule removal failed (page likely closed)',
+        );
+      }
+    }
+    this.#registered.clear();
+  }
+
+  /** Runs when a registered overlay interrupts an action. */
+  async #onOverlay(rule: OverlayRule, overlay: Locator): Promise<void> {
+    const text = await this.#readText(overlay);
+
+    if (rule.dismiss === undefined) {
+      this.#detections.push({ rule: rule.name, text, dismissed: false });
+      this.#log.warn(
+        { rule: rule.name, text },
+        'Overlay interrupted an action and was left in place (detect-only rule)',
+      );
+      return;
+    }
+
+    try {
+      await rule.dismiss(overlay);
+      this.#detections.push({ rule: rule.name, text, dismissed: true });
+      // Deliberately `warn`, not `debug`: a dismissal changed what the test saw,
+      // and that must be visible when reviewing a pass.
+      this.#log.warn({ rule: rule.name, text }, 'Overlay dismissed automatically');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.#detections.push({ rule: rule.name, text, dismissed: false, error: message });
+      this.#log.warn(
+        { rule: rule.name, text, error: message },
+        'Overlay dismissal failed; leaving the action to fail on its own terms',
+      );
+    }
+  }
+
+  /** Reads overlay text defensively — diagnosis must never throw. */
+  async #readText(overlay: Locator): Promise<string> {
+    try {
+      const raw = await overlay.first().textContent();
+      return (raw ?? '').trim().slice(0, MAX_TEXT_LENGTH);
+    } catch {
+      return '';
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ export { expect, test } from './fixtures/index.js';
 export { authTest, browserBindTest, coreTest, moduleTest } from './fixtures/index.js';
 export { screencastTest } from './fixtures/index.js';
 export { webStorageTest } from './fixtures/index.js';
+export { overlayTest, OverlayHandler, BUILT_IN_OVERLAY_RULES } from './fixtures/index.js';
+export type { OverlayFixtures, OverlayDetection, OverlayRule } from './fixtures/index.js';
 export type { ExtendedUI5Handler } from './fixtures/index.js';
 export type {
   ScreencastFixture,

--- a/tests/unit/fixtures/overlay-fixtures.test.ts
+++ b/tests/unit/fixtures/overlay-fixtures.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright (c) ZesTest 2025-2030. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file may contain AI-assisted code.
+ * See LICENSE and NOTICE files for details.
+ */
+
+/**
+ * Tests for `src/fixtures/overlay-fixtures.ts` — the `overlays` Playwright fixture.
+ *
+ * @remarks
+ * Covers the wiring the handler's own tests cannot reach: built-in registration
+ * gated on config, report attachment, teardown, and the rule that fixture
+ * plumbing must never fail a test on its own account.
+ *
+ * @module fixtures
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockTestExtend } from '../../helpers/mock-playwright-test.js';
+
+// ── Mock Playwright ─────────────────────────────────────────────────
+
+const mockTestExtend = createMockTestExtend();
+
+vi.mock('@playwright/test', () => ({
+  test: { extend: mockTestExtend },
+}));
+
+// ── Mock handler ────────────────────────────────────────────────────
+
+const mockRegisterAll = vi.fn().mockResolvedValue(undefined);
+const mockDispose = vi.fn().mockResolvedValue(undefined);
+let mockDetections: unknown[] = [];
+
+const mockOverlayHandler = vi.fn().mockImplementation(function mockHandler(
+  this: Record<string, unknown>,
+) {
+  this['registerAll'] = mockRegisterAll;
+  this['dispose'] = mockDispose;
+  Object.defineProperty(this, 'detections', { get: () => mockDetections });
+});
+
+vi.mock('../../../src/fixtures/overlay-handler.js', () => ({
+  OverlayHandler: mockOverlayHandler,
+  BUILT_IN_OVERLAY_RULES: [{ name: 'unexpected-dialog', selector: '.sapMDialog' }],
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────
+
+const { overlayTest } = await import('#fixtures/overlay-fixtures.js');
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const fixtures = (overlayTest as unknown as { _fixtureDefinitions: Record<string, unknown> })
+  ._fixtureDefinitions;
+
+function extractFixtureFn(definition: unknown): (...args: unknown[]) => Promise<void> {
+  if (Array.isArray(definition)) {
+    return definition[0] as (...args: unknown[]) => Promise<void>;
+  }
+  return definition as (...args: unknown[]) => Promise<void>;
+}
+
+interface MockTestInfo {
+  attach: ReturnType<typeof vi.fn>;
+}
+
+function createTestInfo(): MockTestInfo {
+  return { attach: vi.fn().mockResolvedValue(undefined) };
+}
+
+/** Runs the fixture through setup, body, and teardown. */
+async function runOverlayFixture(
+  deps: Record<string, unknown>,
+  testInfo: MockTestInfo = createTestInfo(),
+): Promise<unknown> {
+  const fn = extractFixtureFn(fixtures['overlays']);
+  let captured: unknown;
+  const useFn = async (value: unknown): Promise<void> => {
+    captured = value;
+    await Promise.resolve();
+  };
+  await fn(deps, useFn, testInfo);
+  return captured;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('fixtures/overlay-fixtures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDetections = [];
+  });
+
+  it('exports overlayTest with an overlays fixture', () => {
+    expect(fixtures).toHaveProperty('overlays');
+  });
+
+  describe('built-in registration', () => {
+    it('registers the built-in rules by default', async () => {
+      await runOverlayFixture({ page: {}, pramanConfig: {} });
+
+      expect(mockRegisterAll).toHaveBeenCalledOnce();
+    });
+
+    it('registers built-ins when overlays.enabled is true', async () => {
+      await runOverlayFixture({ page: {}, pramanConfig: { overlays: { enabled: true } } });
+
+      expect(mockRegisterAll).toHaveBeenCalledOnce();
+    });
+
+    it('skips registration when overlays.enabled is false', async () => {
+      await runOverlayFixture({ page: {}, pramanConfig: { overlays: { enabled: false } } });
+
+      expect(mockRegisterAll).not.toHaveBeenCalled();
+    });
+
+    it('never fails the test when registration throws', async () => {
+      // Overlay handling is a convenience. A registration failure must not
+      // take down a test that would otherwise pass.
+      mockRegisterAll.mockRejectedValueOnce(new Error('page closed'));
+
+      await expect(runOverlayFixture({ page: {}, pramanConfig: {} })).resolves.toBeDefined();
+    });
+  });
+
+  describe('reporting', () => {
+    it('attaches detections when overlays interrupted the test', async () => {
+      mockDetections = [{ rule: 'unexpected-dialog', text: 'Session Expiring', dismissed: false }];
+      const testInfo = createTestInfo();
+
+      await runOverlayFixture({ page: {}, pramanConfig: {} }, testInfo);
+
+      expect(testInfo.attach).toHaveBeenCalledWith(
+        'overlay-detections',
+        expect.objectContaining({ contentType: 'application/json' }),
+      );
+    });
+
+    it('attaches nothing when no overlay interrupted the test', async () => {
+      const testInfo = createTestInfo();
+
+      await runOverlayFixture({ page: {}, pramanConfig: {} }, testInfo);
+
+      expect(testInfo.attach).not.toHaveBeenCalled();
+    });
+
+    it('never fails the test when attachment throws', async () => {
+      mockDetections = [{ rule: 'x', text: 'y', dismissed: false }];
+      const testInfo = createTestInfo();
+      testInfo.attach.mockRejectedValueOnce(new Error('report closed'));
+
+      await expect(
+        runOverlayFixture({ page: {}, pramanConfig: {} }, testInfo),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('teardown', () => {
+    it('disposes the handler so registrations do not leak into the next test', async () => {
+      await runOverlayFixture({ page: {}, pramanConfig: {} });
+
+      expect(mockDispose).toHaveBeenCalledOnce();
+    });
+
+    it('disposes even when registration was skipped', async () => {
+      await runOverlayFixture({ page: {}, pramanConfig: { overlays: { enabled: false } } });
+
+      expect(mockDispose).toHaveBeenCalledOnce();
+    });
+
+    it('disposes even after an attachment failure', async () => {
+      mockDetections = [{ rule: 'x', text: 'y', dismissed: false }];
+      const testInfo = createTestInfo();
+      testInfo.attach.mockRejectedValueOnce(new Error('report closed'));
+
+      await runOverlayFixture({ page: {}, pramanConfig: {} }, testInfo);
+
+      expect(mockDispose).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/tests/unit/fixtures/overlay-handler.test.ts
+++ b/tests/unit/fixtures/overlay-handler.test.ts
@@ -245,6 +245,23 @@ describe('fixtures/overlay-handler', () => {
     });
   });
 
+  describe('non-Error failures', () => {
+    it('records a non-Error dismissal rejection as a string', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({
+        name: 'odd',
+        selector: '.o',
+        dismiss: vi.fn<DismissFn>().mockRejectedValue('boom'),
+      });
+
+      await handlerFor(page)(createMockLocator());
+
+      expect(handler.detections[0]?.dismissed).toBe(false);
+      expect(handler.detections[0]?.error).toBe('boom');
+    });
+  });
+
   describe('dispose', () => {
     it('unregisters every rule', async () => {
       const page = createMockPage();
@@ -257,6 +274,15 @@ describe('fixtures/overlay-handler', () => {
       expect(page.removeLocatorHandler).toHaveBeenCalledTimes(2);
     });
 
+    it('survives a non-Error rejection during removal', async () => {
+      const page = createMockPage();
+      page.removeLocatorHandler.mockRejectedValue('target closed');
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'a', selector: '.a' });
+
+      await expect(handler.dispose()).resolves.toBeUndefined();
+    });
+
     it('survives a page that has already closed', async () => {
       const page = createMockPage();
       page.removeLocatorHandler.mockRejectedValue(new Error('Target page closed'));
@@ -264,6 +290,70 @@ describe('fixtures/overlay-handler', () => {
       await handler.register({ name: 'a', selector: '.a' });
 
       await expect(handler.dispose()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('registerAll', () => {
+    it('registers every rule in the list', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.registerAll([
+        { name: 'a', selector: '.a' },
+        { name: 'b', selector: '.b' },
+      ]);
+
+      expect(page.addLocatorHandler).toHaveBeenCalledTimes(2);
+    });
+
+    it('registers the built-in rules', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.registerAll(BUILT_IN_OVERLAY_RULES);
+
+      expect(page.addLocatorHandler).toHaveBeenCalledTimes(BUILT_IN_OVERLAY_RULES.length);
+    });
+  });
+
+  describe('overlay text capture', () => {
+    it('records empty text when the overlay detaches before it can be read', async () => {
+      // Diagnosis is best-effort: a racing overlay must not break the handler.
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'racing', selector: '.r' });
+
+      const overlay = createMockLocator();
+      (overlay.first as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('element is not attached to the DOM');
+      });
+
+      await handlerFor(page)(overlay);
+
+      expect(handler.detections[0]?.text).toBe('');
+    });
+
+    it('truncates very long overlay text', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'verbose', selector: '.v' });
+
+      await handlerFor(page)(createMockLocator('x'.repeat(500)));
+
+      expect(handler.detections[0]?.text.length).toBeLessThanOrEqual(200);
+    });
+
+    it('handles an overlay with no text at all', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'blank', selector: '.b' });
+
+      const overlay = createMockLocator();
+      (overlay.textContent as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      await handlerFor(page)(overlay);
+
+      expect(handler.detections[0]?.text).toBe('');
     });
   });
 

--- a/tests/unit/fixtures/overlay-handler.test.ts
+++ b/tests/unit/fixtures/overlay-handler.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright (c) ZesTest 2025-2030. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This file may contain AI-assisted code.
+ * See LICENSE and NOTICE files for details.
+ */
+
+/**
+ * Tests for `src/fixtures/overlay-handler.ts` — SAP overlay interruption handling.
+ *
+ * @remarks
+ * Mock strategy: `vi.mock()` for logger, inline `vi.fn()` for page and locator.
+ * These tests pin the behaviour the design review called for: detect-by-default,
+ * dismissal only when explicitly asked for, bounded firing, and clean teardown.
+ *
+ * @module fixtures
+ */
+
+import type { Locator, Page } from '@playwright/test';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockChildLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+const mockCreateLogger = vi.fn().mockReturnValue(mockChildLogger);
+
+vi.mock('#core/logging/logger.js', () => ({
+  createLogger: mockCreateLogger,
+}));
+
+const { OverlayHandler, BUILT_IN_OVERLAY_RULES } = await import('#fixtures/overlay-handler.js');
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+type RegisteredHandler = (locator: Locator) => Promise<void>;
+
+type MockPage = Page & {
+  addLocatorHandler: ReturnType<typeof vi.fn>;
+  removeLocatorHandler: ReturnType<typeof vi.fn>;
+  locator: ReturnType<typeof vi.fn>;
+};
+
+function createMockLocator(text = 'Session Expiring'): Locator {
+  const loc = {
+    first: vi.fn(),
+    textContent: vi.fn().mockResolvedValue(text),
+    click: vi.fn().mockResolvedValue(undefined),
+    isVisible: vi.fn().mockResolvedValue(true),
+  };
+  loc.first.mockReturnValue(loc);
+  return loc as unknown as Locator;
+}
+
+function createMockPage(): MockPage {
+  const page = {
+    addLocatorHandler: vi.fn().mockResolvedValue(undefined),
+    removeLocatorHandler: vi.fn().mockResolvedValue(undefined),
+    locator: vi.fn().mockImplementation(() => createMockLocator()),
+  };
+  return page as unknown as MockPage;
+}
+
+/** Pulls the handler callback Playwright would invoke for the Nth registration. */
+function handlerFor(page: MockPage, index = 0): RegisteredHandler {
+  const call = page.addLocatorHandler.mock.calls[index] as unknown[];
+  return call[1] as RegisteredHandler;
+}
+
+/** Pulls the options object passed alongside the Nth registration. */
+function optionsFor(page: MockPage, index = 0): { times?: number; noWaitAfter?: boolean } {
+  const call = page.addLocatorHandler.mock.calls[index] as unknown[] | undefined;
+  return call?.[2] ?? {};
+}
+
+/** Dismiss stub typed to the rule signature. `vi.fn` satisfies the promise lint rules. */
+type DismissFn = (overlay: Locator) => Promise<void>;
+
+function noopDismiss(): DismissFn {
+  return vi.fn<DismissFn>().mockResolvedValue(undefined);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('fixtures/overlay-handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('register', () => {
+    it('registers the rule with Playwright', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.register({ name: 'cookie-consent', selector: '.myCookieBar' });
+
+      expect(page.locator).toHaveBeenCalledWith('.myCookieBar');
+      expect(page.addLocatorHandler).toHaveBeenCalledOnce();
+    });
+
+    it('caps how many times a rule may fire', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.register({ name: 'toast', selector: '.sapMMessageToast', times: 3 });
+
+      expect(optionsFor(page).times).toBe(3);
+    });
+
+    it('applies a default firing cap when none is given', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.register({ name: 'toast', selector: '.sapMMessageToast' });
+
+      expect(optionsFor(page).times).toBeGreaterThan(0);
+    });
+
+    it('rejects a duplicate rule name', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.register({ name: 'dup', selector: '.a' });
+
+      await expect(handler.register({ name: 'dup', selector: '.b' })).rejects.toThrow(/dup/);
+    });
+  });
+
+  // The review's R3: dismissing must never be the default, because a framework
+  // that silently answers a dialog can turn a real failure into a false pass.
+  describe('detect-only rules (default)', () => {
+    it('does not click anything when no dismiss function is given', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'unexpected-dialog', selector: '.sapMDialog' });
+
+      const overlay = createMockLocator('Unsaved changes');
+      await handlerFor(page)(overlay);
+
+      expect(overlay.click).not.toHaveBeenCalled();
+    });
+
+    it('records the detection so it can be reported', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'unexpected-dialog', selector: '.sapMDialog' });
+
+      await handlerFor(page)(createMockLocator('Session Expiring'));
+
+      expect(handler.detections).toHaveLength(1);
+      expect(handler.detections[0]?.rule).toBe('unexpected-dialog');
+      expect(handler.detections[0]?.dismissed).toBe(false);
+    });
+
+    it('captures the overlay text to turn a blocked action into a diagnosis', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'unexpected-dialog', selector: '.sapMDialog' });
+
+      await handlerFor(page)(createMockLocator('Session Expiring'));
+
+      expect(handler.detections[0]?.text).toContain('Session Expiring');
+    });
+
+    it('does not wait for a detect-only overlay to disappear', async () => {
+      // Nothing dismissed it, so waiting for it to hide would stall the action
+      // until timeout and bury the diagnosis.
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.register({ name: 'unexpected-dialog', selector: '.sapMDialog' });
+
+      expect(optionsFor(page).noWaitAfter).toBe(true);
+    });
+  });
+
+  describe('dismissal rules (opt-in)', () => {
+    it('runs the dismiss function when one is provided', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      const dismiss = vi.fn<DismissFn>().mockResolvedValue(undefined) as unknown as DismissFn;
+      await handler.register({ name: 'cookie-consent', selector: '.cookie', dismiss });
+
+      const overlay = createMockLocator('Accept cookies');
+      await handlerFor(page)(overlay);
+
+      expect(dismiss).toHaveBeenCalledWith(overlay);
+    });
+
+    it('marks the detection as dismissed', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({
+        name: 'cookie-consent',
+        selector: '.cookie',
+        dismiss: noopDismiss(),
+      });
+
+      await handlerFor(page)(createMockLocator());
+
+      expect(handler.detections[0]?.dismissed).toBe(true);
+    });
+
+    it('warns on every dismissal so it is visible in review, not silent', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({
+        name: 'cookie-consent',
+        selector: '.cookie',
+        dismiss: noopDismiss(),
+      });
+
+      await handlerFor(page)(createMockLocator());
+
+      expect(mockChildLogger.warn).toHaveBeenCalled();
+    });
+
+    it('waits for a dismissed overlay to disappear by default', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+
+      await handler.register({ name: 'cookie', selector: '.cookie', dismiss: noopDismiss() });
+
+      expect(optionsFor(page).noWaitAfter).toBe(false);
+    });
+
+    it('never lets a failing dismiss abort the test run', async () => {
+      // The overlay handler is a convenience. If dismissal fails the action
+      // should proceed and fail on its own terms, with the failure recorded.
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({
+        name: 'flaky',
+        selector: '.x',
+        dismiss: vi.fn<DismissFn>().mockRejectedValue(new Error('element detached')),
+      });
+
+      await expect(handlerFor(page)(createMockLocator())).resolves.toBeUndefined();
+      expect(handler.detections[0]?.dismissed).toBe(false);
+      expect(handler.detections[0]?.error).toContain('element detached');
+    });
+  });
+
+  describe('dispose', () => {
+    it('unregisters every rule', async () => {
+      const page = createMockPage();
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'a', selector: '.a' });
+      await handler.register({ name: 'b', selector: '.b' });
+
+      await handler.dispose();
+
+      expect(page.removeLocatorHandler).toHaveBeenCalledTimes(2);
+    });
+
+    it('survives a page that has already closed', async () => {
+      const page = createMockPage();
+      page.removeLocatorHandler.mockRejectedValue(new Error('Target page closed'));
+      const handler = new OverlayHandler({ page });
+      await handler.register({ name: 'a', selector: '.a' });
+
+      await expect(handler.dispose()).resolves.toBeUndefined();
+    });
+  });
+
+  // R2: busy/blocking state belongs to waitForUI5Stable. Registering a handler
+  // for it too would put two independent wait mechanisms on every action.
+  describe('built-in rules', () => {
+    it('ships a detect-only rule for unexpected modal dialogs', () => {
+      const dialogRule = BUILT_IN_OVERLAY_RULES.find((r) => r.selector.includes('sapMDialog'));
+
+      expect(dialogRule).toBeDefined();
+      expect(dialogRule?.dismiss).toBeUndefined();
+    });
+
+    it('does not target BusyIndicator or the block layer', () => {
+      const selectors = BUILT_IN_OVERLAY_RULES.map((r) => r.selector).join(' ');
+
+      expect(selectors).not.toContain('BusyIndicator');
+      expect(selectors).not.toContain('BlockLayer');
+    });
+
+    it('dismisses nothing by default', () => {
+      expect(BUILT_IN_OVERLAY_RULES.every((r) => r.dismiss === undefined)).toBe(true);
+    });
+
+    it('uses plain CSS, never the ui5= engine, to keep per-action cost low', () => {
+      // Playwright evaluates every registered locator before every action; the
+      // ui5= engine walks the whole control tree.
+      expect(BUILT_IN_OVERLAY_RULES.every((r) => !r.selector.startsWith('ui5='))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Phase 1 of the Playwright feature-adoption plan. `page.addLocatorHandler()` has existed since **1.42**, well below our **1.57** floor — so this ships with **no version gate and no compatibility cost**.

## What it does

SAP Fiori interrupts flows unpredictably — modal dialogs, cookie banners, product tours — and today every test anticipates them imperatively. That's where a large share of SAP flakiness originates.

Adds `OverlayHandler` and the `overlays` fixture (merged into `test`, exported from the public barrel), plus an `overlays.enabled` config flag.

## Three constraints from the design review

**Detect, don't dismiss.** A handler that silently answers a dialog turns a real failure into a passing test — for a library selling trustworthy SAP tests, shipping that as a default would be an own goal. Rules report by default; dismissal is opt-in per rule and logged at `warn`, so it's visible when reviewing a pass rather than invisible.

**Busy state is not an overlay.** `BusyIndicator` and the block layer stay with `waitForUI5Stable`. Registering handlers for them too would put two independent wait mechanisms on every action with no defined precedence when they disagree. This was my original headline example, and it was cut deliberately.

**Plain CSS for built-ins.** Playwright evaluates every registered locator before *every* action; the `ui5=` engine walks the whole control tree. Built-ins use `.sapMDialog`, already relied on by `src/scripts/dialog-controls.ts`. User rules may opt into `ui5=` where control semantics are genuinely needed.

## The one built-in

Detect-only. It turns an opaque `click timed out` into *"a modal reading 'Session Expiring' blocked this click"*, attached to the report as `overlay-detections`.

Which overlays actually appear is highly system-specific (What's New, cookie consent, custom Z-dialogs), so dismissal rules belong in the consuming project rather than shipped as guesses I can't verify against a real system.

```typescript
await overlays.register({
  name: 'cookie-consent',
  selector: '#cookieBanner',
  dismiss: async (overlay) => overlay.getByRole('button', { name: 'Accept' }).click(),
});
```

## Verification

`npm run ci` green — 4616 tests (+37), attw and knip clean, 3 capability entries registered, per-file coverage thresholds met.

**Verified against real Chromium, not only mocks** — a green mock suite is exactly what let #224 ship:

- a blocking overlay produces the named diagnosis with `dismissed: false`, and the firing cap holds at 5
- an opt-in dismissal rule unblocks a click that was previously impossible

Two things that exercise found which unit tests could not:

1. `OverlayHandler` was **missing from the public barrel** — consumers could not import it. Mocks import the module directly, so nothing caught it.
2. The pre-push coverage gate then caught the fixture at **7.69%** — its wiring had no tests at all. Fixed in the follow-up commit.